### PR TITLE
Update CTA text for pricing buttons

### DIFF
--- a/src/components/Pages/Home/Home.js
+++ b/src/components/Pages/Home/Home.js
@@ -2432,7 +2432,7 @@ const Content = (props) => {
                     "pricing-panel-early"
                   )
                 }
-                text={"Work with us"}
+                text={"Book intro call"}
                 color1={Colors.blue}
                 color2={Colors.blueDark}
               />
@@ -2492,7 +2492,7 @@ const Content = (props) => {
                     "pricing-panel-growth"
                   )
                 }
-                text={"Work with us"}
+                text={"Book intro call"}
                 color1={Colors.blue}
                 color2={Colors.blueDark}
               />
@@ -2551,7 +2551,7 @@ const Content = (props) => {
                     "pricing-panel-scale"
                   )
                 }
-                text={"Work with us"}
+                text={"Book intro call"}
                 color1={Colors.blue}
                 color2={Colors.blueDark}
               />
@@ -2610,7 +2610,7 @@ const Content = (props) => {
                     "pricing-panel-mature"
                   )
                 }
-                text={"Work with us"}
+                text={"Book intro call"}
                 color1={Colors.blue}
                 color2={Colors.blueDark}
               />


### PR DESCRIPTION
## Summary
- Replace the "Work with us" label on pricing call-to-action buttons with "Book intro call"

## Testing
- `npm test -- --watchAll=false` *(fails: existing Jest configuration cannot parse lucide-react ESM import)*

------
https://chatgpt.com/codex/tasks/task_e_68c95ec640a483278c1bbed44b8a84eb