### PR TITLE
Fix Jest config for lucide-react and stabilize App test

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,12 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "jest": {
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\](?!lucide-react[/\\\\]).+\\.(js|jsx|mjs|cjs|ts|tsx)$",
+      "^.+\\.module\\.(css|sass|scss)$"
+    ]
+  },
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,13 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
+import React from "react";
+import { render } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+beforeAll(() => {
+  window.scrollTo = jest.fn();
+});
+
+test("renders the application layout", () => {
+  const { container } = render(<App />);
+  const appRoot = container.querySelector(".App");
+  expect(appRoot).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- adjust Jest transform ignore patterns so lucide-react's ESM build is transpiled during tests
- update App.test.js to use a more representative assertion and stub window.scrollTo

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c9a6de32c88327b7eb426621f49aaa