### PR TITLE
Add build step to FTP deployment workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,34 @@
-name: Deploy to Server
+name: Build and Deploy to FTP
+
 on:
   push:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
-  deploy:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: FTP-Deploy-Action
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.3
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload build via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USER }}
           password: ${{ secrets.FTP_PASSWORD }}
-          local-dir: "./"
+          local-dir: build
+          server-dir: /


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions workflow installs dependencies and runs the build before deploying
- update the workflow to deploy the generated `build` directory to the FTP server using the latest action versions

## Testing
- npm ci
- npm run build *(fails: existing lint error in src/components/Pages/Home/Home.js reports `e` is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ca50bd7c208327820bbf95c3f0712a