### PR TITLE
Standardize button components with shared styling

### DIFF
--- a/src/components/Button/ButtonMedium.js
+++ b/src/components/Button/ButtonMedium.js
@@ -2,107 +2,43 @@ import React from "react";
 import styled from "@emotion/styled";
 import Icon from "@mdi/react";
 import { Colors } from "../DesignSystem";
+import {
+  buttonBaseStyles,
+  getGradientBackground,
+  getHoverColor,
+} from "./buttonStyles";
 
-const ButtonMedium = ({ href, text, color1, color2, icon, clickAction }) => {
-  console.log(`color:${color1};`);
-  let csscolor = null;
-  if (color1 && color2) {
-    csscolor = `background-image: linear-gradient(to right, ${color1}, ${color2});`;
-  } else {
-    csscolor = `background-image: linear-gradient(to right, #ff6d00, #ff9e40);`;
+const StyledMediumButton = styled("a", {
+  shouldForwardProp: (prop) => prop !== "color1" && prop !== "color2",
+})`
+  ${buttonBaseStyles};
+  padding: 16px 32px;
+  border-radius: 8px;
+  font-size: 17px;
+  line-height: 130%;
+  letter-spacing: 0.02em;
+  color: ${Colors.textWhite.highEmphasis};
+  background-image: ${({ color1, color2 }) =>
+    getGradientBackground(color1, color2)};
+  background-color: transparent;
+
+  &:hover {
+    background-image: none;
+    background-color: ${({ color1, color2 }) =>
+      getHoverColor(color1, color2)};
   }
-  const ButtonMedium = styled.a`
-    align-items: flex-start;
-    appearance: auto;
-    background-attachment: scroll;
-    background-clip: border-box;
-    ${csscolor};
-    background-origin: padding-box;
-    background-position-x: 0%;
-    background-position-y: 0%;
-    background-size: auto;
+`;
 
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-
-    border-bottom-style: none;
-    border-top-style: none;
-    border-left-style: none;
-    border-right-style: none;
-
-    border-bottom-width: 0px;
-    border-top-width: 0px;
-    border-right-width: 0px;
-    border-left-width: 0px;
-
-    border-image-outset: 0;
-    border-image-repeat: stretch;
-    border-image-slice: 100%;
-    border-image-source: none;
-    border-image-width: 1;
-
-    border-left-color: rgb(255, 255, 255);
-    border-right-color: rgb(255, 255, 255);
-    border-top-color: rgb(255, 255, 255);
-    border-bottom-color: rgb(255, 255, 255);
-
-    color: rgba(255, 255, 255, 1);
-    cursor: pointer;
-    direction: ltr;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
-
-    margin: 0px;
-    min-width: 51px;
-
-    overflow-x: visible;
-    overflow-y: visible;
-
-    padding: 16px 32px;
-
-    font-style: normal;
-    font-weight: 500;
-    font-size: 17px;
-    line-height: 130%;
-
-    quotes: "“" "”";
-    text-align: center;
-    text-indent: 0px;
-    text-rendering: auto;
-    text-shadow: none;
-    text-size-adjust: 100%;
-    text-transform: none;
-    vertical-align: baseline;
-
-    letter-spacing: 0.02em;
-
-    word-spacing: 0px;
-    writing-mode: horizontal-tb;
-    -webkit-font-smoothing: antialiased;
-    border-image: none;
-    -webkit-border-image: none;
-
-    text-decoration: none;
-    &:hover {
-      background-color: ${color2 || "#000000"};
-      background-image: none;
-    }
-    &:visited {
-      text-decoration: none;
-    }
-  `;
-
-  return (
-    <ButtonMedium href={href} onClick={clickAction}>
-      {text}
-      {icon && <Icon path={icon} title={text} size={"16px"} />}
-    </ButtonMedium>
-  );
-};
+const ButtonMedium = ({ href, text, color1, color2, icon, clickAction }) => (
+  <StyledMediumButton
+    href={href}
+    onClick={clickAction}
+    color1={color1}
+    color2={color2}
+  >
+    {text}
+    {icon && <Icon path={icon} title={text} size="16px" />}
+  </StyledMediumButton>
+);
 
 export default ButtonMedium;

--- a/src/components/Button/ButtonMediumSecondary.js
+++ b/src/components/Button/ButtonMediumSecondary.js
@@ -2,108 +2,43 @@ import React from "react";
 import styled from "@emotion/styled";
 import Icon from "@mdi/react";
 import { Colors } from "../DesignSystem";
+import { buttonBaseStyles } from "./buttonStyles";
 
-const ButtonMedium = ({ href, text, color1, color2, icon, clickAction }) => {
-  console.log(`color:${color1};`);
-  let csscolor = null;
-  if (color1 && color2) {
-    csscolor = `background-image: linear-gradient(to right, ${color1}, ${color2});`;
-  } else {
-    csscolor = `background-image: linear-gradient(to right, #ff6d00, #ff9e40);`;
+const StyledMediumSecondaryButton = styled("a", {
+  shouldForwardProp: (prop) => prop !== "color1" && prop !== "color2",
+})`
+  ${buttonBaseStyles};
+  padding: 16px 32px;
+  border-radius: 8px;
+  font-size: 17px;
+  line-height: 130%;
+  letter-spacing: 0.02em;
+  background-color: ${Colors.blueVeryLight};
+  color: ${({ color1 }) => color1 || Colors.blueDark};
+
+  &:hover {
+    background-color: ${Colors.blueLight};
+    color: ${({ color1, color2 }) => color2 || color1 || Colors.blueDark};
   }
-  const ButtonMedium = styled.a`
-    align-items: flex-start;
-    appearance: auto;
-    background-attachment: scroll;
-    background-clip: border-box;
+`;
 
-    background-color: ${Colors.blueVeryLight};
-    background-origin: padding-box;
-    background-position-x: 0%;
-    background-position-y: 0%;
-    background-size: auto;
+const ButtonMediumSecondary = ({
+  href,
+  text,
+  color1,
+  color2,
+  icon,
+  clickAction,
+}) => (
+  <StyledMediumSecondaryButton
+    href={href}
+    onClick={clickAction}
+    color1={color1}
+    color2={color2}
+  >
+    {text}
+    {icon && <Icon path={icon} title={text} size="16px" />}
+  </StyledMediumSecondaryButton>
+);
 
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-
-    border-bottom-style: none;
-    border-top-style: none;
-    border-left-style: none;
-    border-right-style: none;
-
-    border-bottom-width: 0px;
-    border-top-width: 0px;
-    border-right-width: 0px;
-    border-left-width: 0px;
-
-    border-image-outset: 0;
-    border-image-repeat: stretch;
-    border-image-slice: 100%;
-    border-image-source: none;
-    border-image-width: 1;
-
-    border-left-color: rgb(255, 255, 255);
-    border-right-color: rgb(255, 255, 255);
-    border-top-color: rgb(255, 255, 255);
-    border-bottom-color: rgb(255, 255, 255);
-
-    color: linear-gradient(to right, ${color1}, ${color2});
-    cursor: pointer;
-    direction: ltr;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
-
-    margin: 0px;
-    min-width: 51px;
-
-    overflow-x: visible;
-    overflow-y: visible;
-
-    padding: 16px 32px;
-
-    font-style: normal;
-    font-weight: 500;
-    font-size: 17px;
-    line-height: 130%;
-
-    quotes: "“" "”";
-    text-align: center;
-    text-indent: 0px;
-    text-rendering: auto;
-    text-shadow: none;
-    text-size-adjust: 100%;
-    text-transform: none;
-    vertical-align: baseline;
-
-    letter-spacing: 0.02em;
-
-    word-spacing: 0px;
-    writing-mode: horizontal-tb;
-    -webkit-font-smoothing: antialiased;
-    border-image: none;
-    -webkit-border-image: none;
-
-    text-decoration: none;
-    &:hover {
-      background-color: ${Colors.blueLight};
-      ${Colors.blueDark}
-    }
-    &:visited {
-      text-decoration: none;
-    }
-  `;
-
-  return (
-    <ButtonMedium href={href} onClick={clickAction}>
-      {text}
-      {icon && <Icon path={icon} title={text} size={"16px"} />}
-    </ButtonMedium>
-  );
-};
-
-export default ButtonMedium;
+export default ButtonMediumSecondary;

--- a/src/components/Button/ButtonMediumText.js
+++ b/src/components/Button/ButtonMediumText.js
@@ -1,7 +1,26 @@
 import React from "react";
 import styled from "@emotion/styled";
-import Icon from "@mdi/react";
 import { Colors } from "../DesignSystem";
+import { buttonBaseStyles } from "./buttonStyles";
+
+const StyledMediumTextButton = styled("a", {
+  shouldForwardProp: (prop) => prop !== "color1" && prop !== "color2",
+})`
+  ${buttonBaseStyles};
+  padding: 16px 32px;
+  border-radius: 8px;
+  font-size: 17px;
+  line-height: 130%;
+  letter-spacing: 0.02em;
+  background-color: transparent;
+  color: ${({ color1 }) => color1 || Colors.blue};
+
+  &:hover {
+    background-color: ${Colors.greyLight};
+    color: ${({ color1, color2 }) =>
+      color2 || color1 || Colors.primaryText.highEmphasis};
+  }
+`;
 
 const ButtonMediumText = ({
   href,
@@ -10,78 +29,16 @@ const ButtonMediumText = ({
   text,
   icon,
   clickAction,
-}) => {
-  let csscolor = null;
-  if (color1 && color2) {
-    csscolor = `background-image: linear-gradient(to right, ${color1}, ${color2});`;
-  } else {
-    csscolor = `background-image: linear-gradient(to right, #ff6d00, #ff9e40);`;
-  }
-  const ButtonMediumText = styled.a`
-    align-items: flex-start;
-    appearance: auto;
-
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-
-    color: ${color1};
-    cursor: pointer;
-    direction: ltr;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
-
-    margin: 0px;
-    min-width: 51px;
-
-    overflow-x: visible;
-    overflow-y: visible;
-
-    padding: 16px 32px;
-
-    font-style: normal;
-    font-weight: 500;
-    font-size: 17px;
-    line-height: 130%;
-
-    quotes: "“" "”";
-    text-align: center;
-    text-indent: 0px;
-    text-rendering: auto;
-    text-shadow: none;
-    text-size-adjust: 100%;
-    text-transform: none;
-    vertical-align: baseline;
-
-    letter-spacing: 0.02em;
-
-    word-spacing: 0px;
-    writing-mode: horizontal-tb;
-    -webkit-font-smoothing: antialiased;
-    border-image: none;
-    -webkit-border-image: none;
-
-    text-decoration: none;
-    &:hover {
-      background-color: ${Colors.greyLight};
-      color: ${Colors.primaryText.highEmphasis};
-      cursor: pointer;
-    }
-    &:visited {
-      text-decoration: none;
-    }
-  `;
-
-  return (
-    <ButtonMediumText href={href} onClick={clickAction}>
-      {text}
-      {icon && icon}
-    </ButtonMediumText>
-  );
-};
+}) => (
+  <StyledMediumTextButton
+    href={href}
+    onClick={clickAction}
+    color1={color1}
+    color2={color2}
+  >
+    {text}
+    {icon && icon}
+  </StyledMediumTextButton>
+);
 
 export default ButtonMediumText;

--- a/src/components/Button/ButtonSmall.js
+++ b/src/components/Button/ButtonSmall.js
@@ -1,108 +1,44 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { motion } from "framer-motion";
 import Icon from "@mdi/react";
+import { Colors } from "../DesignSystem";
+import {
+  buttonBaseStyles,
+  getGradientBackground,
+  getHoverColor,
+} from "./buttonStyles";
 
-const ButtonSmall = ({ href, text, color1, color2, icon, clickAction }) => {
-  console.log(`color:${color1};`);
-  let csscolor = null;
-  if (color1 && color2) {
-    csscolor = `background-image: linear-gradient(to right, ${color1}, ${color2});`;
-  } else {
-    csscolor = `background-image: linear-gradient(to right, #ff6d00, #ff9e40);`;
+const StyledSmallButton = styled("a", {
+  shouldForwardProp: (prop) => prop !== "color1" && prop !== "color2",
+})`
+  ${buttonBaseStyles};
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 133%;
+  letter-spacing: 0.01em;
+  color: ${Colors.textWhite.highEmphasis};
+  background-image: ${({ color1, color2 }) =>
+    getGradientBackground(color1, color2)};
+  background-color: transparent;
+
+  &:hover {
+    background-image: none;
+    background-color: ${({ color1, color2 }) =>
+      getHoverColor(color1, color2)};
   }
-  const ButtonSmall = styled.a`
-    align-items: flex-start;
-    appearance: auto;
-    background-attachment: scroll;
-    background-clip: border-box;
-    ${csscolor};
-    background-origin: padding-box;
-    background-position-x: 0%;
-    background-position-y: 0%;
-    background-size: auto;
+`;
 
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-
-    border-bottom-style: none;
-    border-top-style: none;
-    border-left-style: none;
-    border-right-style: none;
-
-    border-bottom-width: 0px;
-    border-top-width: 0px;
-    border-right-width: 0px;
-    border-left-width: 0px;
-
-    border-image-outset: 0;
-    border-image-repeat: stretch;
-    border-image-slice: 100%;
-    border-image-source: none;
-    border-image-width: 1;
-
-    border-left-color: rgb(255, 255, 255);
-    border-right-color: rgb(255, 255, 255);
-    border-top-color: rgb(255, 255, 255);
-    border-bottom-color: rgb(255, 255, 255);
-
-    color: rgba(255, 255, 255, 1);
-    cursor: pointer;
-    direction: ltr;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
-
-    margin: 0px;
-    min-width: 51px;
-    height: fit-content;
-
-    overflow-x: visible;
-    overflow-y: visible;
-
-    padding: 4px 10px;
-
-    font-style: normal;
-    font-weight: 500;
-    font-size: 12px;
-    line-height: 133%;
-
-    quotes: "“" "”";
-    text-align: center;
-    text-indent: 0px;
-    text-rendering: auto;
-    text-shadow: none;
-    text-size-adjust: 100%;
-    text-transform: none;
-    vertical-align: baseline;
-
-    letter-spacing: 0.01em;
-
-    word-spacing: 0px;
-    writing-mode: horizontal-tb;
-    -webkit-font-smoothing: antialiased;
-    border-image: none;
-    -webkit-border-image: none;
-
-    text-decoration: none;
-    &:hover {
-      color: rgba(255, 255, 255, 1);
-    }
-    &:visited {
-      text-decoration: none;
-    }
-  `;
-
-  return (
-    <ButtonSmall href={href} onClick={clickAction}>
-      {text}
-      {icon && <Icon path={icon} title={text} size={"16px"} />}
-    </ButtonSmall>
-  );
-};
+const ButtonSmall = ({ href, text, color1, color2, icon, clickAction }) => (
+  <StyledSmallButton
+    href={href}
+    onClick={clickAction}
+    color1={color1}
+    color2={color2}
+  >
+    {text}
+    {icon && <Icon path={icon} title={text} size="16px" />}
+  </StyledSmallButton>
+);
 
 export default ButtonSmall;

--- a/src/components/Button/ButtonSmallSecondary.js
+++ b/src/components/Button/ButtonSmallSecondary.js
@@ -1,8 +1,26 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { motion } from "framer-motion";
 import Icon from "@mdi/react";
 import { Colors } from "../DesignSystem";
+import { buttonBaseStyles } from "./buttonStyles";
+
+const StyledSmallSecondaryButton = styled("a", {
+  shouldForwardProp: (prop) => prop !== "color1" && prop !== "color2",
+})`
+  ${buttonBaseStyles};
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 133%;
+  letter-spacing: 0.01em;
+  background-color: ${Colors.blueVeryLight};
+  color: ${({ color1 }) => color1 || Colors.blueDark};
+
+  &:hover {
+    background-color: ${Colors.blueLight};
+    color: ${({ color1, color2 }) => color2 || color1 || Colors.blueDark};
+  }
+`;
 
 const ButtonSmallSecondary = ({
   href,
@@ -11,108 +29,16 @@ const ButtonSmallSecondary = ({
   color2,
   icon,
   clickAction,
-}) => {
-  console.log(`color:${color1};`);
-  let csscolor = null;
-  if (color1 && color2) {
-    csscolor = `background-image: linear-gradient(to right, ${color1}, ${color2});`;
-  } else {
-    csscolor = `background-image: linear-gradient(to right, #ff6d00, #ff9e40);`;
-  }
-  const ButtonSmallSecondary = styled.a`
-    align-items: flex-start;
-    appearance: auto;
-    background-attachment: scroll;
-    background-clip: border-box;
-
-    background-color: ${Colors.blueVeryLight};
-    background-origin: padding-box;
-    background-position-x: 0%;
-    background-position-y: 0%;
-    background-size: auto;
-
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-
-    border-bottom-style: none;
-    border-top-style: none;
-    border-left-style: none;
-    border-right-style: none;
-
-    border-bottom-width: 0px;
-    border-top-width: 0px;
-    border-right-width: 0px;
-    border-left-width: 0px;
-
-    border-image-outset: 0;
-    border-image-repeat: stretch;
-    border-image-slice: 100%;
-    border-image-source: none;
-    border-image-width: 1;
-
-    border-left-color: rgb(255, 255, 255);
-    border-right-color: rgb(255, 255, 255);
-    border-top-color: rgb(255, 255, 255);
-    border-bottom-color: rgb(255, 255, 255);
-
-    color: linear-gradient(to right, ${color1}, ${color2});
-    cursor: pointer;
-    direction: ltr;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
-
-    margin: 0px;
-    min-width: 51px;
-    height: fit-content;
-
-    overflow-x: visible;
-    overflow-y: visible;
-
-    padding: 4px 10px;
-
-    font-style: normal;
-    font-weight: 500;
-    font-size: 12px;
-    line-height: 133%;
-
-    quotes: "“" "”";
-    text-align: center;
-    text-indent: 0px;
-    text-rendering: auto;
-    text-shadow: none;
-    text-size-adjust: 100%;
-    text-transform: none;
-    vertical-align: baseline;
-
-    letter-spacing: 0.01em;
-
-    word-spacing: 0px;
-    writing-mode: horizontal-tb;
-    -webkit-font-smoothing: antialiased;
-    border-image: none;
-    -webkit-border-image: none;
-
-    text-decoration: none;
-    &:hover {
-      background-color: ${Colors.blueLight};
-      ${Colors.blueDark}
-    }
-    &:visited {
-      text-decoration: none;
-    }
-  `;
-
-  return (
-    <ButtonSmallSecondary href={href} onClick={clickAction}>
-      {text}
-      {icon && <Icon path={icon} title={text} size={"16px"} />}
-    </ButtonSmallSecondary>
-  );
-};
+}) => (
+  <StyledSmallSecondaryButton
+    href={href}
+    onClick={clickAction}
+    color1={color1}
+    color2={color2}
+  >
+    {text}
+    {icon && <Icon path={icon} title={text} size="16px" />}
+  </StyledSmallSecondaryButton>
+);
 
 export default ButtonSmallSecondary;

--- a/src/components/Button/buttonStyles.js
+++ b/src/components/Button/buttonStyles.js
@@ -1,0 +1,42 @@
+import { css } from "@emotion/react";
+import { Colors } from "../DesignSystem";
+
+const DEFAULT_GRADIENT_START = Colors.orange;
+const DEFAULT_GRADIENT_END = Colors.orangeLight;
+
+export const buttonBaseStyles = css`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 0;
+  min-width: 51px;
+  border: none;
+  cursor: pointer;
+  font-style: normal;
+  font-weight: 500;
+  text-align: center;
+  text-decoration: none;
+  transition: background-color 0.2s ease, background-image 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:visited {
+    color: inherit;
+    text-decoration: none;
+  }
+`;
+
+export const getGradientBackground = (color1, color2) => {
+  if (color1 && color2) {
+    return `linear-gradient(to right, ${color1}, ${color2})`;
+  }
+
+  return `linear-gradient(to right, ${DEFAULT_GRADIENT_START}, ${DEFAULT_GRADIENT_END})`;
+};
+
+export const getHoverColor = (color1, color2) =>
+  color2 || color1 || Colors.orangeDark;


### PR DESCRIPTION
## Summary
- add shared button style helpers to consolidate common styling logic
- refactor medium and small button variants to use the shared helpers and remove inline styled duplication
- align secondary and text button variants with the new structure and consistent hover behaviour

## Testing
- npm test -- --watchAll=false *(fails: lucide-react esm module parsing issue in jest)*

------
https://chatgpt.com/codex/tasks/task_e_68ca64d77cac8327b08035e923ee779e