### PR TITLE
Update workflow to use master branch and SFTP deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Build and Deploy to FTP
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-and-deploy:
@@ -24,11 +24,13 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Upload build via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+      - name: Upload build via SFTP
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
         with:
-          server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USER }}
           password: ${{ secrets.FTP_PASSWORD }}
-          local-dir: build
-          server-dir: /
+          server: ${{ secrets.FTP_SERVER }}
+          port: ${{ secrets.FTP_PORT || 22 }}
+          local_path: ./build/
+          remote_path: /
+          sftp_only: true


### PR DESCRIPTION
## Summary
- update the workflow trigger to run on the master branch instead of main so it matches the repository default
- switch the deployment step to upload over SFTP for secure transfers

## Testing
- no automated tests were run (workflow configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68ca6b1d2a48832787345d6090b2a031