### PR TITLE
Fix sticky hook event handling and stabilize tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -120,11 +120,10 @@ function App() {
         <Helmet>
           <meta charSet="utf-8" />
           <title>Alexandros Shomper</title>
-          <description>
-            Experienced in core and growth initiatives from acquisition to
-            retention & engagement. Bridging business, design, and tech to
-            create awesome solutions people love.
-          </description>
+          <meta
+            name="description"
+            content="Experienced in core and growth initiatives from acquisition to retention & engagement. Bridging business, design, and tech to create awesome solutions people love."
+          />
         </Helmet>
         <Suspense fallback={renderLoader()}>
           <Navigation />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,8 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
+import React from "react";
+import { render } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test("renders application container", () => {
+  const { container } = render(<App />);
+  expect(container.querySelector(".App")).toBeInTheDocument();
 });

--- a/src/hooks/useSticky.js
+++ b/src/hooks/useSticky.js
@@ -1,37 +1,27 @@
-import { useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 function useSticky() {
   const [isSticky, setSticky] = useState(false);
   const element = useRef(null);
 
-  const handleScroll = () => {
-    window.scrollY > element.current.getBoundingClientRect().bottom
-      ? setSticky(true)
-      : setSticky(false);
-  };
+  const handleScroll = useCallback(() => {
+    if (!element.current) {
+      setSticky(false);
+      return;
+    }
 
-  const debounce = (func, wait = 20, immediate = true) => {
-    let timeout;
-    return () => {
-      let context = this;
-      let args = arguments;
-      const later = () => {
-        timeout = null;
-        if (!immediate) func.apply(context, args);
-      };
-      const callNow = immediate && !timeout;
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
-      if (callNow) func.apply(context, args);
-    };
-  };
+    const { bottom } = element.current.getBoundingClientRect();
+    setSticky(bottom <= 0);
+  }, []);
 
   useEffect(() => {
-    window.addEventListener("scroll", debounce(handleScroll));
+    window.addEventListener("scroll", handleScroll);
+    handleScroll();
+
     return () => {
-      window.removeEventListener("scroll", () => handleScroll);
+      window.removeEventListener("scroll", handleScroll);
     };
-  }, [debounce, handleScroll]);
+  }, [handleScroll]);
 
   return { isSticky, element };
 }

--- a/src/hooks/useSticky.test.js
+++ b/src/hooks/useSticky.test.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import useSticky from "./useSticky";
+
+describe("useSticky", () => {
+  const TestComponent = () => {
+    const { isSticky, element } = useSticky();
+
+    return (
+      <div>
+        <div ref={element} data-testid="marker" />
+        <span data-testid="status">{isSticky ? "sticky" : "not-sticky"}</span>
+      </div>
+    );
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("toggles sticky state when the marker scrolls out of view", () => {
+    render(<TestComponent />);
+
+    const marker = screen.getByTestId("marker");
+    const status = screen.getByTestId("status");
+
+    act(() => {
+      marker.getBoundingClientRect = () => ({ bottom: 150 });
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(status).toHaveTextContent("not-sticky");
+
+    act(() => {
+      marker.getBoundingClientRect = () => ({ bottom: -5 });
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(status).toHaveTextContent("sticky");
+  });
+
+  test("removes the scroll listener on unmount", () => {
+    const addSpy = jest.spyOn(window, "addEventListener");
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+
+    const { unmount } = render(<TestComponent />);
+
+    const [[, scrollHandler]] = addSpy.mock.calls.filter(
+      ([event]) => event === "scroll"
+    );
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("scroll", scrollHandler);
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,4 +2,22 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import "@testing-library/jest-dom/extend-expect";
+
+jest.mock("lucide-react", () => {
+  const handler = () => null;
+  return new Proxy(
+    { __esModule: true, default: handler },
+    {
+      get: (target, prop) => {
+        if (prop in target) {
+          return target[prop];
+        }
+
+        return handler;
+      },
+    }
+  );
+});
+
+window.scrollTo = jest.fn();


### PR DESCRIPTION
## Summary
- repair the `useSticky` hook so it handles missing refs safely and cleans up scroll listeners correctly
- mock `lucide-react` icons and `window.scrollTo` for the test environment and update the app description meta tag
- expand the test suite with coverage for the sticky behaviour and align the app test with the real markup

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cb1150badc83278ad5d92413b1bf4c