### PR TITLE
Hoist styled components to improve render performance

### DIFF
--- a/src/components/CaseStudySlider/CaseStudySlider.js
+++ b/src/components/CaseStudySlider/CaseStudySlider.js
@@ -4,6 +4,212 @@ import styled from "@emotion/styled";
 import { Colors, Devices } from "../../components/DesignSystem";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
+const SliderRoot = styled.div`
+  /* Auto Layout */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0px;
+  margin-top: 20px;
+  margin-bottom: 40px;
+
+  position: static;
+  left: 0px;
+  top: 0px;
+
+  /* Inside Auto Layout */
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+  width: 90%;
+  scroll-margin-top: 120px;
+  ${Devices.tabletS} {
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 740px;
+  }
+  ${Devices.laptopM} {
+  }
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  text-align: center;
+  max-width: 740px;
+  min-width: 100%;
+  margin: 0 auto;
+  ${Devices.tabletS} {
+    width: 80%;
+  }
+  ${Devices.tabletM} {
+    width: 80%;
+  }
+  ${Devices.laptopS} {
+    width: 80%;
+  }
+  ${Devices.laptopM} {
+  }
+`;
+
+const ImageWrapper = styled.div`
+  min-width: 100%;
+  height: auto;
+  aspect-ratio: 4/3;
+  margin-bottom: 10px;
+  position: relative;
+
+  ${Devices.tabletS} {
+  }
+  ${Devices.tabletM} {
+  }
+  ${Devices.laptopS} {
+  }
+  ${Devices.laptopM} {
+  }
+`;
+
+const Image = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 0.38rem;
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: ${(props) => (props.isVisible ? 1 : 0)};
+  transition: opacity 0.3s ease-in-out;
+  ${Devices.tabletS} {
+  }
+  ${Devices.tabletM} {
+  }
+  ${Devices.laptopS} {
+  }
+  ${Devices.laptopM} {
+  }
+`;
+
+const Spinner = styled.div`
+  border: 4px solid #e5e7eb;
+  border-top: 4px solid ${Colors.blue};
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 0.8s linear infinite;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  @keyframes spin {
+    0% {
+      transform: translate(-50%, -50%) rotate(0deg);
+    }
+    100% {
+      transform: translate(-50%, -50%) rotate(360deg);
+    }
+  }
+`;
+
+const NavigationIndicator = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  flex-grow: 1;
+  gap: 4px;
+  order: -1;
+  ${Devices.tabletS} {
+    justify-content: center;
+    align-items: center;
+    order: 0;
+  }
+`;
+
+const ProgressBar = styled.div`
+  width: 100%;
+  height: 2px;
+  background-color: ${Colors.textWhite.lowEmphasis};
+  border-radius: 1px;
+  position: relative;
+  margin-top: 8px;
+  display: none;
+  ${Devices.tabletS} {
+    display: block;
+  }
+`;
+
+const ProgressFill = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  background-color: ${Colors.blue};
+  border-radius: 1px;
+  transition: width 0.3s ease-in-out;
+  width: ${(props) => (props.progress * 100) / props.total}%;
+`;
+
+const TextGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  gap: 4px;
+`;
+
+const Headline = styled.h3`
+  margin: 0px;
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+const Caption = styled.p`
+  font-size: 14px;
+  font-weight: 400;
+  margin: 0px;
+`;
+
+const Controls = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+`;
+
+const NavButton = styled.button`
+  background-color: ${Colors.textWhite.mediumEmphasis};
+  color: ${Colors.text.mediumEmphasis};
+  border: none;
+  padding: 13px 13px;
+  border-radius: 50%;
+  height: 52px;
+  width: 52px;
+  font-size: 14px;
+  cursor: pointer;
+  touch-action: manipulation;
+  &:hover {
+    background-color: ${Colors.textWhite.highEmphasis};
+    color: ${Colors.text.highEmphasis};
+  }
+  &:disabled {
+    background-color: ${Colors.textWhite.lowEmphasis};
+    color: ${Colors.text.lowEmphasis};
+
+    cursor: not-allowed;
+  }
+`;
+
+const SlideIndicator = styled.span`
+  font-size: 14px;
+  color: ${Colors.primaryText.mediumEmphasis};
+  font-weight: 500;
+`;
+
 const CaseStudySlider = ({ slides }) => {
   const sliderRef = useRef(null);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -60,210 +266,8 @@ const CaseStudySlider = ({ slides }) => {
     }
   }, [currentIndex, preloadImage, slides]);
 
-  const CaseStudySlider = styled.div`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 0px;
-    margin-top: 20px;
-    margin-bottom: 40px;
-
-    position: static;
-    left: 0px;
-    top: 0px;
-
-    /* Inside Auto Layout */
-    flex: none;
-    order: 0;
-    flex-grow: 0;
-    width: 90%;
-    scroll-margin-top: 120px;
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-
-  const Container = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-    text-align: center;
-    max-width: 740px;
-    min-width: 100%;
-    margin: 0 auto;
-    ${Devices.tabletS} {
-      width: 80%;
-    }
-    ${Devices.tabletM} {
-      width: 80%;
-    }
-    ${Devices.laptopS} {
-      width: 80%;
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-
-  const ImageWrapper = styled.div`
-    min-width: 100%;
-    height: auto;
-    aspect-ratio: 4/3;
-    margin-bottom: 10px;
-    position: relative;
-
-    ${Devices.tabletS} {
-    }
-    ${Devices.tabletM} {
-    }
-    ${Devices.laptopS} {
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-
-  const Image = styled.img`
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    border-radius: 0.38rem;
-    position: absolute;
-    top: 0;
-    left: 0;
-    opacity: ${(props) => (props.isVisible ? 1 : 0)};
-    transition: opacity 0.3s ease-in-out;
-    ${Devices.tabletS} {
-    }
-    ${Devices.tabletM} {
-    }
-    ${Devices.laptopS} {
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-  const Spinner = styled.div`
-    border: 4px solid #e5e7eb;
-    border-top: 4px solid ${Colors.blue};
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    animation: spin 0.8s linear infinite;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-
-    @keyframes spin {
-      0% {
-        transform: translate(-50%, -50%) rotate(0deg);
-      }
-      100% {
-        transform: translate(-50%, -50%) rotate(360deg);
-      }
-    }
-  `;
-  const NavigationIndicator = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: flex-start;
-    flex-grow: 1;
-    gap: 4px;
-    order: -1;
-    ${Devices.tabletS} {
-      justify-content: center;
-      align-items: center;
-      order: 0;
-    }
-  `;
-
-  const ProgressBar = styled.div`
-    width: 100%;
-    height: 2px;
-    background-color: ${Colors.textWhite.lowEmphasis};
-    border-radius: 1px;
-    position: relative;
-    margin-top: 8px;
-    display: none;
-    ${Devices.tabletS} {
-      display: block;
-    }
-  `;
-
-  const ProgressFill = styled.div`
-    position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
-    background-color: ${Colors.blue};
-    border-radius: 1px;
-    transition: width 0.3s ease-in-out;
-    width: ${(props) => (props.progress * 100) / props.total}%;
-  `;
-
-  const TextGroup = styled.div`
-    display: flex;
-    flex-dricetion: row;
-    justify-content: center;
-    gap: 4px;
-  `;
-  const Headline = styled.h3`
-    margin: 0px;
-    font-size: 14px;
-    font-weight: 500;
-  `;
-  const Caption = styled.p`
-    font-size: 14px;
-    font-weight: 400;
-    margin: 0px;
-  `;
-
-  const Controls = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 12px;
-  `;
-
-  const NavButton = styled.button`
-    background-color: ${Colors.textWhite.mediumEmphasis};
-    color: ${Colors.text.mediumEmphasis};
-    border: none;
-    padding: 13px 13px;
-    border-radius: 50%;
-    height: 52px;
-    width: 52px;
-    font-size: 14px;
-    cursor: pointer;
-    touch-action: manipulation;
-    &:hover {
-      background-color: ${Colors.textWhite.highEmphasis};
-      color: ${Colors.text.highEmphasis};
-    }
-    &:disabled {
-      background-color: ${Colors.textWhite.lowEmphasis};
-      color: ${Colors.text.lowEmphasis};
-
-      cursor: not-allowed;
-    }
-  `;
-
-  const SlideIndicator = styled.span`
-    font-size: 14px;
-    color: ${Colors.primaryText.mediumEmphasis};
-    font-weight: 500;
-  `;
-
   return (
-    <CaseStudySlider ref={sliderRef}>
+    <SliderRoot ref={sliderRef}>
       <Container>
         <ImageWrapper>
           {loading && <Spinner />}
@@ -322,7 +326,7 @@ const CaseStudySlider = ({ slides }) => {
           </NavButton>
         </Controls>
       </Container>
-    </CaseStudySlider>
+    </SliderRoot>
   );
 };
 

--- a/src/components/Gallery/GalleryList.js
+++ b/src/components/Gallery/GalleryList.js
@@ -4,34 +4,34 @@ import GalleryItem from "./GalleryItem";
 
 import { Devices } from "../DesignSystem";
 
+const GalleryListWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-auto-rows: minmax(300px, auto);
+  gap: 16px;
+  width: 100%;
+  padding: 24px;
+  box-sizing: border-box;
+  min-height: 100vh;
+
+  ${Devices.tabletS} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  ${Devices.tabletM} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  ${Devices.laptopS} {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  ${Devices.laptopM} {
+    max-width: 1336px;
+    margin: 0 auto;
+  }
+`;
+
 const GalleryList = ({ data, filter }) => {
-  const GalleryList = styled.div`
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    grid-auto-rows: minmax(300px, auto);
-    gap: 16px;
-    width: 100%;
-    padding: 24px;
-    box-sizing: border-box;
-    min-height: 100vh;
-
-    ${Devices.tabletS} {
-      grid-template-columns: repeat(2, 1fr);
-    }
-    ${Devices.tabletM} {
-      grid-template-columns: repeat(2, 1fr);
-    }
-    ${Devices.laptopS} {
-      grid-template-columns: repeat(3, 1fr);
-    }
-    ${Devices.laptopM} {
-      max-width: 1336px;
-      margin: 0 auto;
-    }
-  `;
-
   return (
-    <GalleryList>
+    <GalleryListWrapper>
       {data.map((item) => (
         <GalleryItem
           key={item.id}
@@ -44,7 +44,7 @@ const GalleryList = ({ data, filter }) => {
           comingSoon={item.comingSoon}
         />
       ))}
-    </GalleryList>
+    </GalleryListWrapper>
   );
 };
 


### PR DESCRIPTION
## Summary
- hoist the gallery grid wrapper styled component so it is created once instead of on every render
- move the case study slider styled components to module scope to prevent re-creation work when props/state change

## Testing
- `npm test -- --watchAll=false` *(fails: lucide-react ESM build is not transformed by Jest)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1167b5f08327be38d3e12b2497ef