### PR TITLE
Fix visited link styling for Flow gallery cards

### DIFF
--- a/src/components/Gallery/GalleryItem.js
+++ b/src/components/Gallery/GalleryItem.js
@@ -41,18 +41,18 @@ const GalleryItem = ({ title, desc, logo, thumbnail, slug, comingSoon }) => {
     list-style-type: none;
     position: relative;
     text-align: left;
-    text-decoration-color: blue;
     text-decoration: none;
     text-decoration-style: solid;
     text-decoration-thickness: auto;
     text-size-adjust: 100%;
     -webkit-font-smoothing: antialiased;
+    color: inherit;
 
-    &:hover {
-      color: ${Colors.primaryText.highEmphasis};
-    }
+    &:hover,
+    &:focus,
+    &:active,
     &:visited {
-      color: ${Colors.primaryText.mediumEmphasis};
+      color: inherit;
       text-decoration: none;
     }
   `;


### PR DESCRIPTION
## Summary
- keep Flow Gallery card links inheriting their text color so visited links no longer change the title styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cba2ff6a24832799548ebaec8df8e8