### PR TITLE
Remove positional animations and keep opacity fades

### DIFF
--- a/src/components/Content/CaseCard/CaseCard.js
+++ b/src/components/Content/CaseCard/CaseCard.js
@@ -51,7 +51,6 @@ const CaseCard = ({
   const CaseCardMotion = {
     rest: {
       boxShadow: "0px 0px 0px rgba(0, 0, 0, 0)",
-      scale: 1,
       transition: {
         duration: 0.2,
         type: "tween",
@@ -60,7 +59,6 @@ const CaseCard = ({
     },
     hover: {
       boxShadow: "1px 1px 20px rgba(0, 0, 0, 0.1)",
-      scale: 1.01,
       transition: {
         duration: 0.2,
         type: "tween",
@@ -69,7 +67,6 @@ const CaseCard = ({
     },
     click: {
       boxShadow: "0px 0px 0px rgba(0, 0, 0, 0)",
-      scale: 0.99,
       transition: {
         duration: 0.2,
         type: "tween",
@@ -208,7 +205,7 @@ const CaseCard = ({
       },
     },
     hover: {
-      paddingBottom: "72px",
+      paddingBottom: "24px",
       transition: {
         duration: 0.2,
         type: "tween",
@@ -216,7 +213,7 @@ const CaseCard = ({
       },
     },
     click: {
-      paddingBottom: "72px",
+      paddingBottom: "24px",
       transition: {
         duration: 0.2,
         type: "tween",

--- a/src/components/Content/FlipCard/FlipCard.js
+++ b/src/components/Content/FlipCard/FlipCard.js
@@ -145,14 +145,12 @@ const FlipCard = ({
         variants={{
           visible: {
             opacity: 1,
-            y: 0,
             transition: {
               staggerChildren: 0.3,
             },
           },
           hidden: {
             opacity: 0,
-            y: "-25%",
           },
         }}
       >

--- a/src/components/Content/Landingpage/Head.js
+++ b/src/components/Content/Landingpage/Head.js
@@ -31,13 +31,9 @@ function FadeInWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
         },
         hidden: {
           opacity: 0,
-          scale: 0.95,
-          y: "+5%",
         },
       }}
     >

--- a/src/components/Content/NFTGallery/NFTGallery.js
+++ b/src/components/Content/NFTGallery/NFTGallery.js
@@ -54,7 +54,6 @@ const NFTGallery = ({
   const NFTGalleryMotion = {
     rest: {
       boxShadow: "0px 0px 0px rgba(0, 0, 0, 0)",
-      scale: 1,
       transition: {
         duration: 0.2,
         type: "tween",
@@ -63,7 +62,6 @@ const NFTGallery = ({
     },
     hover: {
       boxShadow: "1px 1px 20px rgba(0, 0, 0, 0.1)",
-      scale: 1.01,
       transition: {
         duration: 0.2,
         type: "tween",
@@ -72,7 +70,6 @@ const NFTGallery = ({
     },
     click: {
       boxShadow: "0px 0px 0px rgba(0, 0, 0, 0)",
-      scale: 0.9,
       transition: {
         duration: 0.2,
         type: "tween",

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -49,7 +49,6 @@ const Navigation = (props) => {
    
   
     z-index: 1000;
-    animation: moveDown 0.5s ease-in-out;
     ${Devices.tabletS} {
      
     }
@@ -119,7 +118,6 @@ const Navigation = (props) => {
     height: 52px;
     z-index: 9999;
 
-    animation: moveDown 0.5s ease-in-out;
     margin-right: 24px;
     margin-left: 24px;
     ${Devices.tabletS} {

--- a/src/components/Navigation/NavigationMenuMobile.js
+++ b/src/components/Navigation/NavigationMenuMobile.js
@@ -20,7 +20,6 @@ const NavigationMenuMobile = (props) => {
    
     
     z-index: 1000;
-    animation: moveDown 0.5s ease-in-out;
     ${Devices.tabletS} {
      
     }
@@ -68,7 +67,6 @@ const NavigationMenuMobile = (props) => {
     height: 52px;
     z-index: 9999;
 
-    animation: moveDown 0.5s ease-in-out;
     margin-right: 24px;
     margin-left: 24px;
     ${Devices.tabletS} {

--- a/src/components/Navigation/NavigationSticky.js
+++ b/src/components/Navigation/NavigationSticky.js
@@ -43,7 +43,6 @@ const NavigationSticky = (props) => {
     background-color: ${Colors.background};
    
     z-index: 1000;
-    animation: moveDown 0.5s ease-in-out;
     ${Devices.tabletS} {
      
     }
@@ -68,7 +67,6 @@ const NavigationSticky = (props) => {
     border-color: ${Colors.primaryText.highEmphasis};
     background-color: ${Colors.background};
     z-index: 1000;
-    animation: moveDown 0.5s ease-in-out;
     margin-right: 24px;
     margin-left: 24px;
     ${Devices.tabletS} {
@@ -122,7 +120,6 @@ const NavigationSticky = (props) => {
     height: 52px;
     z-index: 9999;
 
-    animation: moveDown 0.5s ease-in-out;
     margin-right: 24px;
     margin-left: 24px;
     ${Devices.tabletS} {

--- a/src/components/Pages/Flows/AsanaFlow.js
+++ b/src/components/Pages/Flows/AsanaFlow.js
@@ -37,16 +37,12 @@ function FadeInWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
           transition: {
             staggerChildren: 0.3,
           },
         },
         hidden: {
           opacity: 0,
-          scale: 0.8,
-          y: "+25%",
         },
       }}
     >

--- a/src/components/Pages/Flows/LinearFlow.js
+++ b/src/components/Pages/Flows/LinearFlow.js
@@ -37,16 +37,12 @@ function FadeInWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
           transition: {
             staggerChildren: 0.3,
           },
         },
         hidden: {
           opacity: 0,
-          scale: 0.8,
-          y: "+25%",
         },
       }}
     >

--- a/src/components/Pages/Heraklit/Heraklit.js
+++ b/src/components/Pages/Heraklit/Heraklit.js
@@ -30,16 +30,12 @@ function FadeInWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
           transition: {
             staggerChildren: 0.3,
           },
         },
         hidden: {
           opacity: 0,
-          scale: 0.8,
-          y: "+25%",
         },
       }}
     >

--- a/src/components/Pages/Home/Home.js
+++ b/src/components/Pages/Home/Home.js
@@ -239,14 +239,12 @@ function FadeInWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          y: 0,
           transition: {
             staggerChildren: 0.3,
           },
         },
         hidden: {
-          opacity: 0.5,
-          y: "+15%",
+          opacity: 0,
         },
       }}
     >
@@ -276,8 +274,6 @@ function MoveUpWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
           transition: {
             when: "beforeChildren",
             staggerChildren: 0.3,
@@ -285,8 +281,6 @@ function MoveUpWhenVisible({ children }) {
         },
         hidden: {
           opacity: 0,
-          scale: 0.8,
-          y: "+100%",
           transition: {
             when: "afterChildren",
           },

--- a/src/components/Pages/Portfolio/MyKnauf.js
+++ b/src/components/Pages/Portfolio/MyKnauf.js
@@ -38,16 +38,12 @@ function FadeInWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
           transition: {
             staggerChildren: 0.3,
           },
         },
         hidden: {
           opacity: 0,
-          scale: 0.8,
-          y: "+25%",
         },
       }}
     >

--- a/src/components/Pages/Portfolio/Portfolio.js
+++ b/src/components/Pages/Portfolio/Portfolio.js
@@ -30,16 +30,12 @@ function FadeInWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
           transition: {
             staggerChildren: 0.3,
           },
         },
         hidden: {
           opacity: 0,
-          scale: 0.8,
-          y: "+25%",
         },
       }}
     >

--- a/src/components/Pages/Profile/Profile.js
+++ b/src/components/Pages/Profile/Profile.js
@@ -40,16 +40,12 @@ function FadeInWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
           transition: {
             staggerChildren: 0.3,
           },
         },
         hidden: {
           opacity: 0,
-          scale: 0.8,
-          y: "+25%",
         },
       }}
     >
@@ -77,8 +73,6 @@ function MoveUpWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          scale: 1,
-          y: 0,
           transition: {
             when: "beforeChildren",
             staggerChildren: 0.3,
@@ -86,8 +80,6 @@ function MoveUpWhenVisible({ children }) {
         },
         hidden: {
           opacity: 0,
-          scale: 0.8,
-          y: "+100%",
           transition: {
             when: "afterChildren",
           },
@@ -118,7 +110,6 @@ function RevealWhenVisible({ children }) {
       variants={{
         visible: {
           opacity: 1,
-          x: 0,
           transition: {
             when: "beforeChildren",
             staggerChildren: 0.3,
@@ -126,7 +117,6 @@ function RevealWhenVisible({ children }) {
         },
         hidden: {
           opacity: 0,
-          x: "5%",
           transition: {
             when: "afterChildren",
           },


### PR DESCRIPTION
## Summary
- update FadeIn/MoveUp/Reveal helpers across home, profile, portfolio, flows, and related content to animate opacity only
- eliminate scale and padding hover animations on case cards and NFT gallery items
- remove moveDown CSS animations from navigation wrappers

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cba3938bcc83279a48834fbe5dd46b