### PR TITLE
Refine lightbox close button styling

### DIFF
--- a/src/components/Content/PricingCanvas/PricingCanvas.jsx
+++ b/src/components/Content/PricingCanvas/PricingCanvas.jsx
@@ -3,7 +3,7 @@ import ReactGA from "react-ga4";
 import styled from "@emotion/styled";
 
 import { Devices, Colors } from "../../DesignSystem";
-import { Check, Calculator } from "lucide-react";
+import { Check, Calculator, X } from "lucide-react";
 
 import ButtonMediumText from "../../Button/ButtonMediumText";
 const PricingCanvas = ({ roiCalcAction }) => {
@@ -437,21 +437,43 @@ const PricingCanvas = ({ roiCalcAction }) => {
 
   const CloseLightboxButton = styled.button`
     position: absolute;
-    top: 8px;
-    right: 8px;
-    width: 36px;
-    height: 36px;
+    top: 16px;
+    right: 16px;
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     border: none;
-    background: rgba(255, 255, 255, 0.9);
-    color: #000;
+    background: #000000;
+    color: #ffffff;
     cursor: pointer;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 20px;
-    line-height: 1;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    padding: 0;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+    z-index: 2;
+    transition: transform 120ms ease, background-color 120ms ease,
+      box-shadow 120ms ease;
+
+    &:hover {
+      background: #101010;
+      transform: scale(1.03);
+      box-shadow: 0 16px 36px rgba(0, 0, 0, 0.4);
+    }
+
+    &:active {
+      transform: scale(0.97);
+    }
+
+    &:focus-visible {
+      outline: 2px solid #ffffff;
+      outline-offset: 2px;
+    }
+
+    & svg {
+      width: 20px;
+      height: 20px;
+    }
   `;
 
   const LOOM_VIDEO_URL =
@@ -523,7 +545,7 @@ const PricingCanvas = ({ roiCalcAction }) => {
                 onClick={() => setIsLightboxOpen(false)}
                 aria-label="Close video"
               >
-                ×
+                <X aria-hidden="true" strokeWidth={2.5} />
               </CloseLightboxButton>
               <iframe
                 src={LOOM_VIDEO_URL}

--- a/src/components/Lightbox/Lightbox.jsx
+++ b/src/components/Lightbox/Lightbox.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
+import { X } from "lucide-react";
 
 import { Devices } from "../DesignSystem";
 
@@ -66,26 +67,44 @@ const ScrollArea = styled.div`
 `;
 
 const CloseButton = styled.button`
-  position: sticky;
-  top: 0;
-  align-self: flex-end;
-  width: 40px;
-  height: 40px;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   border: none;
-  background: rgba(0, 0, 0, 0.5);
+  background: #000000;
   color: #ffffff;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
-  line-height: 1;
-  z-index: 1;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
-  margin-bottom: 16px;
+  padding: 0;
+  z-index: 2;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  transition: transform 120ms ease, background-color 120ms ease,
+    box-shadow 120ms ease;
+
+  &:hover {
+    background: #101010;
+    transform: scale(1.03);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.4);
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+  }
+
+  & svg {
+    width: 20px;
+    height: 20px;
+  }
 `;
 
 const Lightbox = ({
@@ -134,15 +153,15 @@ const Lightbox = ({
         $maxHeight={maxHeight}
         className={className}
       >
+        <CloseButton type="button" onClick={onClose} aria-label={closeLabel}>
+          <X aria-hidden="true" strokeWidth={2.5} />
+        </CloseButton>
         <ScrollArea
           $padding={contentPadding}
           $paddingTablet={contentPaddingTablet}
           $paddingBottom={contentPaddingBottom}
           $paddingBottomTablet={contentPaddingBottomTablet}
         >
-          <CloseButton type="button" onClick={onClose} aria-label={closeLabel}>
-            ×
-          </CloseButton>
           {children}
         </ScrollArea>
       </LightboxContainer>

--- a/src/components/Pages/Home/Home.js
+++ b/src/components/Pages/Home/Home.js
@@ -21,7 +21,7 @@ import Checkbox from "../../Checkbox/Checkbox";
 
 import DeliverablesCard from "../../Content/DeliverablesCard/DeliverablesCard";
 
-import { Check } from "lucide-react";
+import { Check, X } from "lucide-react";
 import AccordeonVisual from "../../Content/AccordeonVisual/AccordeonVisual";
 import PricingCanvas from "../../Content/PricingCanvas/PricingCanvas";
 import Lightbox from "../../Lightbox/Lightbox";
@@ -1367,21 +1367,43 @@ const LightboxContent = styled.div`
 
 const CloseLightboxButton = styled.button`
   position: absolute;
-  top: 8px;
-  right: 8px;
-  width: 36px;
-  height: 36px;
+  top: 16px;
+  right: 16px;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   border: none;
-  background: rgba(255, 255, 255, 0.9);
-  color: #000;
+  background: #000000;
+  color: #ffffff;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
-  line-height: 1;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  padding: 0;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  z-index: 2;
+  transition: transform 120ms ease, background-color 120ms ease,
+    box-shadow 120ms ease;
+
+  &:hover {
+    background: #101010;
+    transform: scale(1.03);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.4);
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+  }
+
+  & svg {
+    width: 20px;
+    height: 20px;
+  }
 `;
 
 const Content = (props) => {
@@ -1634,7 +1656,7 @@ const Content = (props) => {
                   onClick={() => setIsLightboxOpen(false)}
                   aria-label="Close video"
                 >
-                  ×
+                  <X aria-hidden="true" strokeWidth={2.5} />
                 </CloseLightboxButton>
                 <iframe
                   src={LOOM_VIDEO_URL}


### PR DESCRIPTION
## Summary
- restyle the shared lightbox close control so it is a floating black circular button that uses the lucide X icon
- align the home and pricing video lightboxes with the new floating close button styling for consistency

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cc32f267048327abaaa9a467ae2802