### PR TITLE
Create reusable report template for report pages

### DIFF
--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -1,208 +1,92 @@
-import styled from "@emotion/styled";
 import React from "react";
-import { Helmet } from "react-helmet";
-
-//Components
-import { Colors, Devices } from "../../DesignSystem";
 
 import CaseCopy from "../../Content/Case/CaseCopy";
 import CaseHeadlineThree from "../../Content/Case/CaseHeadlineThree";
 import CaseSectionHead from "../../Content/Case/CaseSectionHead";
-import CaseTitle from "../../Content/Case/CaseTitle";
-import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
-
-import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
+import ReportTemplate, {
+  ReportParagraph,
+  ReportUnorderedList,
+  ReportListItem,
+} from "./ReportTemplate";
 
-const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
-
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-
-    align-self: stretch;
-    flex-grow: 0;
-  `;
-
-  const Paragraph = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 140px;
-  `;
-
-  const CaseUnorderedList = styled.ul`
-    position: static;
-
-    font-family: "Roboto", sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    color: ${Colors.primaryText.highEmphasis};
-
-    list-style-type: circle;
-    list-style-image: none;
-
-    list-style-position: outside;
-    padding-left: 0px;
-
-    /* Inside Auto Layout */
-
-    font-size: 24px;
-    line-height: 130%;
-
-    margin: 8px auto;
-    width: 90%;
-
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-
-  const CaseUnorderedListItem = styled.li`
-    margin-bottom: 12px;
-  `;
-
+const FourIndustryShifts = () => {
   return (
-    <Content>
-      <Helmet>
-        <meta charSet="utf-8" />
-        <title>
-          Four industry shifts making user onboarding & activation indispensible
-          | Alexandros Shomper
-        </title>
-        <description>
-          For early-stage and growth startup founders, retention is everything.
-          But what if the key to higher retention and ARR isn't just engagement
-          or new features? Our latest whitepaper dives into why user onboarding
-          and activation are the most powerful (and cost-effective) levers for
-          boosting long-term retention and revenue. Discover how optimizing
-          these critical stages can drastically reduce churn, increase customer
-          lifetime value, and accelerate growth. Download the full report to
-          uncover the strategies top SaaS companies use to turn new users into
-          loyal, paying customers.
-        </description>
-      </Helmet>
-      <Section>
-        <CaseTitleEyebrow text={"Report"} color1="#00b8d4" color2="#62ebff" />
-        <CaseTitle
-          headline={
-            "Four industry shifts making user onboarding & activation indispensible"
-          }
-        />
-        <CaseSubline subline="User Onboarding & Activation: a strategic imperative for growth, retention, and survival." />
+    <ReportTemplate
+      metaTitle="Four industry shifts making user onboarding & activation indispensible | Alexandros Shomper"
+      metaDescription="For early-stage and growth startup founders, retention is everything. But what if the key to higher retention and ARR isn't just engagement or new features? Our latest whitepaper dives into why user onboarding and activation are the most powerful (and cost-effective) levers for boosting long-term retention and revenue. Discover how optimizing these critical stages can drastically reduce churn, increase customer lifetime value, and accelerate growth. Download the full report to uncover the strategies top SaaS companies use to turn new users into loyal, paying customers."
+      title="Four industry shifts making user onboarding & activation indispensible"
+      subline="User Onboarding & Activation: a strategic imperative for growth, retention, and survival."
+    >
+      <CaseSectionHead
+        headline={"Introduction"}
+        subline={"Is your SaaS equipped for the new-normal?"}
+      />
+      <CaseCopy
+        copy="In today's challenging startup landscape, acquiring and retaining users has never been more critical – or more difficult. This in-depth report reveals why exceptional user onboarding is no longer optional."
+      />
+      <br />
+
+      <ReportParagraph>
+        <CaseHeadlineThree headline={"Our latest report reveals:"} />
+        <ReportUnorderedList>
+          <ReportListItem>Market Dynamics Have Fundamentally Changed</ReportListItem>
+          <ReportListItem>The Funding Environment Has Tightened</ReportListItem>
+          <ReportListItem>Product and Team Structures Have Evolved</ReportListItem>
+          <ReportListItem>External Influences Shape Internal Pressures</ReportListItem>
+        </ReportUnorderedList>
         <br />
         <br />
-        <br />
-        <br />
-        <br />
+        <CaseHeadlineThree headline={"Key Insights You'll Discover:"} />
+        <ReportUnorderedList>
+          <ReportListItem>
+            How market dynamics have fundamentally shifted, making user activation more crucial than ever
+          </ReportListItem>
+          <ReportListItem>
+            Why companies with strong onboarding see up to 86% higher customer lifetime value
+          </ReportListItem>
+          <ReportListItem>
+            The direct link between onboarding quality and key metrics like CAC, CLV, and NRR
+          </ReportListItem>
+          <ReportListItem>
+            Real-world examples and case studies from successful companies
+          </ReportListItem>
+        </ReportUnorderedList>
+      </ReportParagraph>
+      <ReportParagraph>
         <CaseSectionHead
-          headline={"Introduction"}
-          subline={"Is your SaaS equipped for the new-normal?"}
+          headline={"Who this report is for"}
+          subline={"We designed this report for founders of early-stage and growth startups who are:"}
         />
-        <CaseCopy
-          copy={
-            "In today's challenging startup landscape, acquiring and retaining users has never been more critical – or more difficult. This in-depth report reveals why exceptional user onboarding is no longer optional."
-          }
-        />
+
+        <ReportUnorderedList>
+          <ReportListItem>
+            Startup founders and product leaders seeking sustainable growth
+          </ReportListItem>
+          <ReportListItem>
+            SaaS companies struggling with user retention and activation
+          </ReportListItem>
+          <ReportListItem>
+            Product teams looking to optimize their onboarding experience
+          </ReportListItem>
+          <ReportListItem>
+            Growth managers focused on improving key metrics
+          </ReportListItem>
+        </ReportUnorderedList>
         <br />
+        <CaseCopy
+          copy="Download now to understand why user onboarding and activation have become the cornerstone of sustainable business growth in today's market."
+        />
 
-        <Paragraph>
-          <CaseHeadlineThree headline={"Our latest report reveals:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Market Dynamics Have Fundamentally Changed
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              The Funding Environment Has Tightened
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Product and Team Structures Have Evolved
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              External Influences Shape Internal Pressures
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-          <br />
-          <br />
-          <CaseHeadlineThree headline={"Key Insights You'll Discover:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              How market dynamics have fundamentally shifted, making user
-              activation more crucial than ever
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Why companies with strong onboarding see up to 86% higher customer
-              lifetime value
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              The direct link between onboarding quality and key metrics like
-              CAC, CLV, and NRR
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Real-world examples and case studies from successful companies
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-        </Paragraph>
-        <Paragraph>
-          <CaseSectionHead
-            headline={"Who this report is for"}
-            subline={
-              "We designed this report for founders of early-stage and growth startups who are:"
-            }
-          />
-
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Startup founders and product leaders seeking sustainable growth
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              SaaS companies struggling with user retention and activation
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Product teams looking to optimize their onboarding experience
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Growth managers focused on improving key metrics
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-          <br />
-          <CaseCopy
-            copy={
-              "Download now to understand why user onboarding and activation have become the cornerstone of sustainable business growth in today's market."
-            }
-          />
-
-          <LeadGenerationForm
-            portal={"49351608"}
-            form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
-            size={"M"}
-            successLink="./report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf"
-          />
-        </Paragraph>
-      </Section>
-    </Content>
+        <LeadGenerationForm
+          portal={"49351608"}
+          form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
+          size={"M"}
+          successLink="./report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf"
+        />
+      </ReportParagraph>
+    </ReportTemplate>
   );
 };
 
-export default Content;
+export default FourIndustryShifts;

--- a/src/components/Pages/Reports/OASaasGrowth.js
+++ b/src/components/Pages/Reports/OASaasGrowth.js
@@ -1,225 +1,113 @@
-import styled from "@emotion/styled";
 import React from "react";
-import { Helmet } from "react-helmet";
-
-//Components
-import { Colors, Devices } from "../../DesignSystem";
 
 import CaseCopy from "../../Content/Case/CaseCopy";
 import CaseHeadlineThree from "../../Content/Case/CaseHeadlineThree";
 import CaseSectionHead from "../../Content/Case/CaseSectionHead";
-import CaseTitle from "../../Content/Case/CaseTitle";
-import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
-
-import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
+import ReportTemplate, {
+  ReportParagraph,
+  ReportUnorderedList,
+  ReportListItem,
+} from "./ReportTemplate";
 
-const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
-
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-
-    align-self: stretch;
-    flex-grow: 0;
-  `;
-
-  const Paragraph = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 140px;
-  `;
-
-  const CaseUnorderedList = styled.ul`
-    position: static;
-
-    font-family: "Roboto", sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    color: ${Colors.primaryText.highEmphasis};
-
-    list-style-type: circle;
-    list-style-image: none;
-
-    list-style-position: outside;
-    padding-left: 0px;
-
-    /* Inside Auto Layout */
-
-    font-size: 24px;
-    line-height: 130%;
-
-    margin: 8px auto;
-    width: 90%;
-
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-
-  const CaseUnorderedListItem = styled.li`
-    margin-bottom: 12px;
-  `;
-
+const OASaasGrowth = () => {
   return (
-    <Content>
-      <Helmet>
-        <meta charSet="utf-8" />
-        <title>
-          Why Onboarding & Activation Are The Ultimate Levers for SaaS Growth |
-          Alexandros Shomper
-        </title>
-        <description>
-          For early-stage and growth startup founders, retention is everything.
-          But what if the key to higher retention and ARR isn't just engagement
-          or new features? Our latest whitepaper dives into why user onboarding
-          and activation are the most powerful (and cost-effective) levers for
-          boosting long-term retention and revenue. Discover how optimizing
-          these critical stages can drastically reduce churn, increase customer
-          lifetime value, and accelerate growth. Download the full report to
-          uncover the strategies top SaaS companies use to turn new users into
-          loyal, paying customers.
-        </description>
-      </Helmet>
-      <Section>
-        <CaseTitleEyebrow text={"Report"} color1="#00b8d4" color2="#62ebff" />
-        <CaseTitle
-          headline={
-            "Why Onboarding & Activation Are The Ultimate Levers for SaaS Growth"
-          }
-        />
-        <CaseSubline subline="User Onboarding & Activation: The Secret to Long-Term Retention & ARR Growth" />
+    <ReportTemplate
+      metaTitle="Why Onboarding & Activation Are The Ultimate Levers for SaaS Growth | Alexandros Shomper"
+      metaDescription="For early-stage and growth startup founders, retention is everything. But what if the key to higher retention and ARR isn't just engagement or new features? Our latest whitepaper dives into why user onboarding and activation are the most powerful (and cost-effective) levers for boosting long-term retention and revenue. Discover how optimizing these critical stages can drastically reduce churn, increase customer lifetime value, and accelerate growth. Download the full report to uncover the strategies top SaaS companies use to turn new users into loyal, paying customers."
+      title="Why Onboarding & Activation Are The Ultimate Levers for SaaS Growth"
+      subline="User Onboarding & Activation: The Secret to Long-Term Retention & ARR Growth"
+    >
+      <CaseSectionHead
+        headline={"Introduction"}
+        subline={"Is your SaaS growth strategy truly built for the long run?"}
+      />
+      <CaseCopy
+        copy="For early-stage and growth startup founders, the path to sustainable growth isn't just about acquiring new users – it's about keeping them. And the most powerful levers for improving retention and ARR? User Onboarding & Activation."
+      />
+      <br />
+      <LeadGenerationForm
+        portal={"49351608"}
+        form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
+        size={"M"}
+        successLink="./reports/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
+      />
+
+      <ReportParagraph>
+        <CaseHeadlineThree headline={"Our latest report reveals:"} />
+        <ReportUnorderedList>
+          <ReportListItem>
+            Why effective onboarding and activation are the most cost-efficient ways to boost retention.
+          </ReportListItem>
+          <ReportListItem>
+            The metrics, frameworks, and psychological insights that make onboarding work.
+          </ReportListItem>
+          <ReportListItem>
+            Case studies from successful SaaS companies like HubSpot, Slack, Robinhood, and more.
+          </ReportListItem>
+          <ReportListItem>
+            How optimizing onboarding & activation impacts critical metrics like CAC:CLV, NRR, and ARR.
+          </ReportListItem>
+        </ReportUnorderedList>
         <br />
         <br />
-        <br />
-        <br />
-        <br />
+        <CaseHeadlineThree headline={"Key Metrics You'll Discover"} />
+        <ReportUnorderedList>
+          <ReportListItem>
+            Improving user onboarding can boost customer retention by up to 50% <i>(Invesp)</i>.
+          </ReportListItem>
+          <ReportListItem>
+            A well-designed onboarding flow can increase revenue by up to 150% over six months.
+          </ReportListItem>
+          <ReportListItem>
+            Reducing churn by just 5% can increase profits by up to 95% <i>(Harvard Business Review)</i>.
+          </ReportListItem>
+        </ReportUnorderedList>
+      </ReportParagraph>
+      <ReportParagraph>
         <CaseSectionHead
-          headline={"Introduction"}
-          subline={"Is your SaaS growth strategy truly built for the long run?"}
+          headline={"Who this report is for"}
+          subline={"We designed this report for founders of early-stage and growth startups who are:"}
         />
-        <CaseCopy
-          copy={
-            "For early-stage and growth startup founders, the path to sustainable growth isn't just about acquiring new users – it's about keeping them. And the most powerful levers for improving retention and ARR? User Onboarding & Activation."
-          }
-        />
+
+        <ReportUnorderedList>
+          <ReportListItem>
+            Struggling with <b>high churn</b> rates and {" "}
+            <b>low user retention</b>.
+          </ReportListItem>
+          <ReportListItem>
+            Finding it <b>hard to convert free users to paying customers</b>.
+          </ReportListItem>
+          <ReportListItem>
+            Seeking cost-effective ways to {" "}
+            <b>improve retention and revenue growth</b>.
+          </ReportListItem>
+          <ReportListItem>
+            Unsure <b>how to measure and optimize onboarding</b> {" "}
+            effectiveness.
+          </ReportListItem>
+          <ReportListItem>
+            Looking to <b>improve CAC:CLV</b> ratios and <b>accelerate ARR</b>
+            growth.
+          </ReportListItem>
+          <ReportListItem>
+            Building or refining their <b>product-led growth strategy</b>.
+          </ReportListItem>
+        </ReportUnorderedList>
         <br />
+        <CaseCopy
+          copy="If you're trying to turn new users into loyal, paying customers, this whitepaper is for you."
+        />
+
         <LeadGenerationForm
           portal={"49351608"}
           form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
           size={"M"}
-          successLink="./reports/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
+          successLink="./report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
         />
-
-        <Paragraph>
-          <CaseHeadlineThree headline={"Our latest report reveals:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Why effective onboarding and activation are the most
-              cost-efficient ways to boost retention.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              The metrics, frameworks, and psychological insights that make
-              onboarding work.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Case studies from successful SaaS companies like HubSpot, Slack,
-              Robinhood, and more.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              How optimizing onboarding & activation impacts critical metrics
-              like CAC:CLV, NRR, and ARR.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-          <br />
-          <br />
-          <CaseHeadlineThree headline={"Key Metrics You'll Discover"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Improving user onboarding can boost customer retention by up to
-              50% <i>(Invesp)</i>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              A well-designed onboarding flow can increase revenue by up to 150%
-              over six months.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Reducing churn by just 5% can increase profits by up to 95%
-              <i>(Harvard Business Review)</i>.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-        </Paragraph>
-        <Paragraph>
-          <CaseSectionHead
-            headline={"Who this report is for"}
-            subline={
-              "We designed this report for founders of early-stage and growth startups who are:"
-            }
-          />
-
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Struggling with <b>high churn</b> rates and{" "}
-              <b>low user retention</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Finding it <b>hard to convert free users to paying customers</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Seeking cost-effective ways to{" "}
-              <b>improve retention and revenue growth</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Unsure <b>how to measure and optimize onboarding</b>{" "}
-              effectiveness.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Looking to <b>improve CAC:CLV</b> ratios and <b>accelerate ARR</b>
-              growth.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Building or refining their <b>product-led growth strategy</b>.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-          <br />
-          <CaseCopy
-            copy={
-              "If you're trying to turn new users into loyal, paying customers, this whitepaper is for you."
-            }
-          />
-
-          <LeadGenerationForm
-            portal={"49351608"}
-            form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
-            size={"M"}
-            successLink="./report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
-          />
-        </Paragraph>
-      </Section>
-    </Content>
+      </ReportParagraph>
+    </ReportTemplate>
   );
 };
 
-export default Content;
+export default OASaasGrowth;

--- a/src/components/Pages/Reports/ReportTemplate.js
+++ b/src/components/Pages/Reports/ReportTemplate.js
@@ -1,0 +1,118 @@
+import styled from "@emotion/styled";
+import React from "react";
+import { Helmet } from "react-helmet";
+
+import { Colors, Devices } from "../../DesignSystem";
+
+import CaseSubline from "../../Content/Case/CaseSubline";
+import CaseTitle from "../../Content/Case/CaseTitle";
+import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
+
+const ContentWrapper = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  align-self: stretch;
+  flex-grow: 0;
+`;
+
+const Paragraph = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  align-self: stretch;
+  flex-grow: 0;
+  margin-bottom: 140px;
+`;
+
+const CaseUnorderedList = styled.ul`
+  position: static;
+
+  font-family: "Roboto", sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  color: ${Colors.primaryText.highEmphasis};
+
+  list-style-type: circle;
+  list-style-image: none;
+
+  list-style-position: outside;
+  padding-left: 0px;
+
+  font-size: 24px;
+  line-height: 130%;
+
+  margin: 8px auto;
+  width: 90%;
+
+  ${Devices.tabletS} {
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 740px;
+  }
+`;
+
+const CaseUnorderedListItem = styled.li`
+  margin-bottom: 12px;
+`;
+
+const HeaderSpacing = () => (
+  <>
+    <br />
+    <br />
+    <br />
+    <br />
+    <br />
+  </>
+);
+
+const ReportTemplate = ({
+  metaTitle,
+  metaDescription,
+  eyebrow = "Report",
+  eyebrowColor1 = "#00b8d4",
+  eyebrowColor2 = "#62ebff",
+  title,
+  subline,
+  children,
+}) => {
+  return (
+    <ContentWrapper>
+      <Helmet>
+        <meta charSet="utf-8" />
+        {metaTitle && <title>{metaTitle}</title>}
+        {metaDescription && (
+          <meta name="description" content={metaDescription} />
+        )}
+      </Helmet>
+      <Section>
+        <CaseTitleEyebrow
+          text={eyebrow}
+          color1={eyebrowColor1}
+          color2={eyebrowColor2}
+        />
+        <CaseTitle headline={title} />
+        {subline ? <CaseSubline subline={subline} /> : null}
+        <HeaderSpacing />
+        {children}
+      </Section>
+    </ContentWrapper>
+  );
+};
+
+export default ReportTemplate;
+export { Paragraph as ReportParagraph };
+export { CaseUnorderedList as ReportUnorderedList };
+export { CaseUnorderedListItem as ReportListItem };
+export { HeaderSpacing as ReportHeaderSpacing };


### PR DESCRIPTION
## Summary
- add a reusable `ReportTemplate` component that centralizes shared layout, metadata, and styling for report pages
- refactor the FourIndustryShifts and OASaasGrowth report pages to consume the new template and shared list/paragraph helpers

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cd5079599c83278f99e2ebd7435f7e