### PR TITLE
Simplify report text styling for reports

### DIFF
--- a/src/components/Content/Report/ReportContent.js
+++ b/src/components/Content/Report/ReportContent.js
@@ -1,0 +1,153 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+import { Colors, Devices } from "../../DesignSystem";
+
+const StyledReportContent = styled.article`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  & > * {
+    width: 90%;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 140px;
+  }
+
+  & > *:last-child {
+    margin-bottom: 0;
+  }
+
+  ${Devices.tabletS} {
+    & > * {
+      width: 564px;
+    }
+  }
+
+  ${Devices.tabletM} {
+    & > * {
+      width: 708px;
+    }
+  }
+
+  ${Devices.laptopS} {
+    & > * {
+      width: 740px;
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: "Roboto", sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    color: ${Colors.primaryText.highEmphasis};
+    text-align: left;
+    margin-top: 0;
+    margin-bottom: 16px;
+    width: 100%;
+  }
+
+  h2 {
+    font-size: 28px;
+    line-height: 109%;
+
+    ${Devices.tabletS} {
+      font-size: 36px;
+    }
+  }
+
+  h3 {
+    font-size: 24px;
+    line-height: 115%;
+    margin-bottom: 8px;
+    color: transparent;
+    background-image: linear-gradient(
+      to right,
+      ${Colors.blue},
+      ${Colors.blueLight}
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+  }
+
+  p {
+    font-family: "Roboto", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 24px;
+    line-height: 132%;
+    color: ${Colors.primaryText.highEmphasis};
+    margin-top: 0;
+    margin-bottom: 40px;
+    width: 100%;
+  }
+
+  ul,
+  ol {
+    font-family: "Roboto", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 24px;
+    line-height: 130%;
+    color: ${Colors.primaryText.highEmphasis};
+    padding-left: 24px;
+    margin-top: 8px;
+    margin-bottom: 40px;
+    width: 100%;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  li {
+    margin-bottom: 12px;
+  }
+
+  li:last-child {
+    margin-bottom: 0;
+  }
+
+  strong {
+    font-weight: 700;
+  }
+
+  em {
+    font-style: italic;
+  }
+
+  a {
+    color: ${Colors.blue};
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+  }
+
+  section > *:last-child,
+  div > *:last-child {
+    margin-bottom: 0;
+  }
+
+  [data-report-form] {
+    width: 100%;
+    margin: 48px auto 40px;
+    display: flex;
+    justify-content: center;
+  }
+
+  [data-report-form] > * {
+    width: 100%;
+  }
+`;
+
+const ReportContent = ({ children }) => {
+  return <StyledReportContent>{children}</StyledReportContent>;
+};
+
+export default ReportContent;

--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
+import styled from "@emotion/styled";
 
 //Components
 import ReportContent from "../../Content/Report/ReportContent";

--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -9,11 +9,7 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
-import ReportTemplate, {
-  ReportParagraph,
-  ReportUnorderedList,
-  ReportListItem,
-} from "./ReportTemplate";
+import ReportTemplate from "./ReportTemplate";
 
 const PageWrapper = styled.div`
   text-align: left;

--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -9,7 +9,6 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
-import ReportTemplate from "./ReportTemplate";
 
 const PageWrapper = styled.div`
   text-align: left;

--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -3,88 +3,30 @@ import React from "react";
 import { Helmet } from "react-helmet";
 
 //Components
-import { Colors, Devices } from "../../DesignSystem";
-
-import CaseCopy from "../../Content/Case/CaseCopy";
-import CaseHeadlineThree from "../../Content/Case/CaseHeadlineThree";
-import CaseSectionHead from "../../Content/Case/CaseSectionHead";
+import ReportContent from "../../Content/Report/ReportContent";
 import CaseTitle from "../../Content/Case/CaseTitle";
 import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
 
-const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
+const PageWrapper = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
 
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  align-self: stretch;
+  flex-grow: 0;
+`;
 
-    /* Inside Auto Layout */
-
-    align-self: stretch;
-    flex-grow: 0;
-  `;
-
-  const Paragraph = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 140px;
-  `;
-
-  const CaseUnorderedList = styled.ul`
-    position: static;
-
-    font-family: "Roboto", sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    color: ${Colors.primaryText.highEmphasis};
-
-    list-style-type: circle;
-    list-style-image: none;
-
-    list-style-position: outside;
-    padding-left: 0px;
-
-    /* Inside Auto Layout */
-
-    font-size: 24px;
-    line-height: 130%;
-
-    margin: 8px auto;
-    width: 90%;
-
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-
-  const CaseUnorderedListItem = styled.li`
-    margin-bottom: 12px;
-  `;
-
+const Content = () => {
   return (
-    <Content>
+    <PageWrapper>
       <Helmet>
         <meta charSet="utf-8" />
         <title>
@@ -111,97 +53,80 @@ const Content = (props) => {
           }
         />
         <CaseSubline subline="User Onboarding & Activation: a strategic imperative for growth, retention, and survival." />
-        <br />
-        <br />
-        <br />
-        <br />
-        <br />
-        <CaseSectionHead
-          headline={"Introduction"}
-          subline={"Is your SaaS equipped for the new-normal?"}
-        />
-        <CaseCopy
-          copy={
-            "In today's challenging startup landscape, acquiring and retaining users has never been more critical – or more difficult. This in-depth report reveals why exceptional user onboarding is no longer optional."
-          }
-        />
-        <br />
-
-        <Paragraph>
-          <CaseHeadlineThree headline={"Our latest report reveals:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Market Dynamics Have Fundamentally Changed
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              The Funding Environment Has Tightened
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Product and Team Structures Have Evolved
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              External Influences Shape Internal Pressures
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-          <br />
-          <br />
-          <CaseHeadlineThree headline={"Key Insights You'll Discover:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              How market dynamics have fundamentally shifted, making user
-              activation more crucial than ever
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Why companies with strong onboarding see up to 86% higher customer
-              lifetime value
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              The direct link between onboarding quality and key metrics like
-              CAC, CLV, and NRR
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Real-world examples and case studies from successful companies
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-        </Paragraph>
-        <Paragraph>
-          <CaseSectionHead
-            headline={"Who this report is for"}
-            subline={
-              "We designed this report for founders of early-stage and growth startups who are:"
-            }
-          />
-
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Startup founders and product leaders seeking sustainable growth
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              SaaS companies struggling with user retention and activation
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Product teams looking to optimize their onboarding experience
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Growth managers focused on improving key metrics
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-          <br />
-          <CaseCopy
-            copy={
-              "Download now to understand why user onboarding and activation have become the cornerstone of sustainable business growth in today's market."
-            }
-          />
-
-          <LeadGenerationForm
-            portal={"49351608"}
-            form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
-            size={"M"}
-            successLink="./report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf"
-          />
-        </Paragraph>
+        <ReportContent>
+          <section>
+            <h2>Introduction</h2>
+            <p>
+              In today's challenging startup landscape, acquiring and retaining
+              users has never been more critical – or more difficult. This
+              in-depth report reveals why exceptional user onboarding is no
+              longer optional.
+            </p>
+          </section>
+          <section>
+            <h3>Our latest report reveals:</h3>
+            <ul>
+              <li>Market dynamics have fundamentally changed.</li>
+              <li>The funding environment has tightened.</li>
+              <li>Product and team structures have evolved.</li>
+              <li>External influences shape internal pressures.</li>
+            </ul>
+            <h3>Key insights you'll discover:</h3>
+            <ul>
+              <li>
+                How market dynamics have fundamentally shifted, making user
+                activation more crucial than ever.
+              </li>
+              <li>
+                Why companies with strong onboarding see up to 86% higher
+                customer lifetime value.
+              </li>
+              <li>
+                The direct link between onboarding quality and key metrics like
+                CAC, CLV, and NRR.
+              </li>
+              <li>
+                Real-world examples and case studies from successful companies.
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3>Who this report is for</h3>
+            <p>
+              We designed this report for founders of early-stage and growth
+              startups who are:
+            </p>
+            <ul>
+              <li>
+                Startup founders and product leaders seeking sustainable growth.
+              </li>
+              <li>
+                SaaS companies struggling with user retention and activation.
+              </li>
+              <li>
+                Product teams looking to optimize their onboarding experience.
+              </li>
+              <li>
+                Growth managers focused on improving key metrics.
+              </li>
+            </ul>
+            <p>
+              Download now to understand why user onboarding and activation have
+              become the cornerstone of sustainable business growth in today's
+              market.
+            </p>
+            <div data-report-form>
+              <LeadGenerationForm
+                portal={"49351608"}
+                form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
+                size={"M"}
+                successLink="./report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf"
+              />
+            </div>
+          </section>
+        </ReportContent>
       </Section>
-    </Content>
+    </PageWrapper>
   );
 };
 

--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -135,4 +135,4 @@ const Content = () => {
   );
 };
 
-export default FourIndustryShifts;
+export default Content;

--- a/src/components/Pages/Reports/OASaasGrowth.js
+++ b/src/components/Pages/Reports/OASaasGrowth.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
+import styled from "@emotion/styled";
 
 //Components
 import ReportContent from "../../Content/Report/ReportContent";

--- a/src/components/Pages/Reports/OASaasGrowth.js
+++ b/src/components/Pages/Reports/OASaasGrowth.js
@@ -9,11 +9,6 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
-import ReportTemplate, {
-  ReportParagraph,
-  ReportUnorderedList,
-  ReportListItem,
-} from "./ReportTemplate";
 
 const PageWrapper = styled.div`
   text-align: left;

--- a/src/components/Pages/Reports/OASaasGrowth.js
+++ b/src/components/Pages/Reports/OASaasGrowth.js
@@ -3,88 +3,30 @@ import React from "react";
 import { Helmet } from "react-helmet";
 
 //Components
-import { Colors, Devices } from "../../DesignSystem";
-
-import CaseCopy from "../../Content/Case/CaseCopy";
-import CaseHeadlineThree from "../../Content/Case/CaseHeadlineThree";
-import CaseSectionHead from "../../Content/Case/CaseSectionHead";
+import ReportContent from "../../Content/Report/ReportContent";
 import CaseTitle from "../../Content/Case/CaseTitle";
 import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
 
-const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
+const PageWrapper = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
 
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  align-self: stretch;
+  flex-grow: 0;
+`;
 
-    /* Inside Auto Layout */
-
-    align-self: stretch;
-    flex-grow: 0;
-  `;
-
-  const Paragraph = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 140px;
-  `;
-
-  const CaseUnorderedList = styled.ul`
-    position: static;
-
-    font-family: "Roboto", sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    color: ${Colors.primaryText.highEmphasis};
-
-    list-style-type: circle;
-    list-style-image: none;
-
-    list-style-position: outside;
-    padding-left: 0px;
-
-    /* Inside Auto Layout */
-
-    font-size: 24px;
-    line-height: 130%;
-
-    margin: 8px auto;
-    width: 90%;
-
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-
-  const CaseUnorderedListItem = styled.li`
-    margin-bottom: 12px;
-  `;
-
+const Content = () => {
   return (
-    <Content>
+    <PageWrapper>
       <Helmet>
         <meta charSet="utf-8" />
         <title>
@@ -111,114 +53,105 @@ const Content = (props) => {
           }
         />
         <CaseSubline subline="User Onboarding & Activation: The Secret to Long-Term Retention & ARR Growth" />
-        <br />
-        <br />
-        <br />
-        <br />
-        <br />
-        <CaseSectionHead
-          headline={"Introduction"}
-          subline={"Is your SaaS growth strategy truly built for the long run?"}
-        />
-        <CaseCopy
-          copy={
-            "For early-stage and growth startup founders, the path to sustainable growth isn't just about acquiring new users – it's about keeping them. And the most powerful levers for improving retention and ARR? User Onboarding & Activation."
-          }
-        />
-        <br />
-        <LeadGenerationForm
-          portal={"49351608"}
-          form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
-          size={"M"}
-          successLink="./reports/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
-        />
-
-        <Paragraph>
-          <CaseHeadlineThree headline={"Our latest report reveals:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Why effective onboarding and activation are the most
-              cost-efficient ways to boost retention.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              The metrics, frameworks, and psychological insights that make
-              onboarding work.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Case studies from successful SaaS companies like HubSpot, Slack,
-              Robinhood, and more.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              How optimizing onboarding & activation impacts critical metrics
-              like CAC:CLV, NRR, and ARR.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-          <br />
-          <br />
-          <CaseHeadlineThree headline={"Key Metrics You'll Discover"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Improving user onboarding can boost customer retention by up to
-              50% <i>(Invesp)</i>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              A well-designed onboarding flow can increase revenue by up to 150%
-              over six months.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Reducing churn by just 5% can increase profits by up to 95%
-              <i>(Harvard Business Review)</i>.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-        </Paragraph>
-        <Paragraph>
-          <CaseSectionHead
-            headline={"Who this report is for"}
-            subline={
-              "We designed this report for founders of early-stage and growth startups who are:"
-            }
-          />
-
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
-              Struggling with <b>high churn</b> rates and{" "}
-              <b>low user retention</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Finding it <b>hard to convert free users to paying customers</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Seeking cost-effective ways to{" "}
-              <b>improve retention and revenue growth</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Unsure <b>how to measure and optimize onboarding</b>{" "}
-              effectiveness.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Looking to <b>improve CAC:CLV</b> ratios and <b>accelerate ARR</b>
-              growth.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
-              Building or refining their <b>product-led growth strategy</b>.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-          <br />
-          <CaseCopy
-            copy={
-              "If you're trying to turn new users into loyal, paying customers, this whitepaper is for you."
-            }
-          />
-
-          <LeadGenerationForm
-            portal={"49351608"}
-            form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
-            size={"M"}
-            successLink="./report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
-          />
-        </Paragraph>
+        <ReportContent>
+          <section>
+            <h2>Introduction</h2>
+            <p>
+              For early-stage and growth startup founders, the path to
+              sustainable growth isn't just about acquiring new users – it's
+              about keeping them. And the most powerful levers for improving
+              retention and ARR? User Onboarding &amp; Activation.
+            </p>
+            <div data-report-form>
+              <LeadGenerationForm
+                portal={"49351608"}
+                form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
+                size={"M"}
+                successLink="./reports/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
+              />
+            </div>
+          </section>
+          <section>
+            <h3>Our latest report reveals:</h3>
+            <ul>
+              <li>
+                Why effective onboarding and activation are the most
+                cost-efficient ways to boost retention.
+              </li>
+              <li>
+                The metrics, frameworks, and psychological insights that make
+                onboarding work.
+              </li>
+              <li>
+                Case studies from successful SaaS companies like HubSpot, Slack,
+                Robinhood, and more.
+              </li>
+              <li>
+                How optimizing onboarding &amp; activation impacts critical metrics
+                like CAC:CLV, NRR, and ARR.
+              </li>
+            </ul>
+            <h3>Key Metrics You'll Discover</h3>
+            <ul>
+              <li>
+                Improving user onboarding can boost customer retention by up to
+                50% <i>(Invesp)</i>.
+              </li>
+              <li>
+                A well-designed onboarding flow can increase revenue by up to
+                150% over six months.
+              </li>
+              <li>
+                Reducing churn by just 5% can increase profits by up to 95%
+                <i>(Harvard Business Review)</i>.
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3>Who this report is for</h3>
+            <p>
+              We designed this report for founders of early-stage and growth
+              startups who are:
+            </p>
+            <ul>
+              <li>
+                Struggling with <strong>high churn</strong> rates and
+                <strong>low user retention</strong>.
+              </li>
+              <li>
+                Finding it <strong>hard to convert free users to paying customers</strong>.
+              </li>
+              <li>
+                Seeking cost-effective ways to <strong>improve retention and revenue growth</strong>.
+              </li>
+              <li>
+                Unsure <strong>how to measure and optimize onboarding</strong>
+                effectiveness.
+              </li>
+              <li>
+                Looking to <strong>improve CAC:CLV</strong> ratios and
+                <strong>accelerate ARR</strong> growth.
+              </li>
+              <li>
+                Building or refining their <strong>product-led growth strategy</strong>.
+              </li>
+            </ul>
+            <p>
+              If you're trying to turn new users into loyal, paying customers,
+              this whitepaper is for you.
+            </p>
+            <div data-report-form>
+              <LeadGenerationForm
+                portal={"49351608"}
+                form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
+                size={"M"}
+                successLink="./report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
+              />
+            </div>
+          </section>
+        </ReportContent>
       </Section>
-    </Content>
+    </PageWrapper>
   );
 };
 

--- a/src/components/Pages/Reports/OASaasGrowth.js
+++ b/src/components/Pages/Reports/OASaasGrowth.js
@@ -160,4 +160,4 @@ const Content = () => {
   );
 };
 
-export default OASaasGrowth;
+export default Content;


### PR DESCRIPTION
## Summary
- add a reusable `ReportContent` wrapper that applies report typography and spacing to basic HTML elements
- refactor the SaaS growth and industry shifts report pages to use semantic HTML and the new wrapper for easier content updates
- center lead generation forms within the new flexible layout

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cd535756048327b64532c48614d8bd