### PR TITLE
Refactor report pages to use shared template

### DIFF
--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -1,129 +1,76 @@
 import React from "react";
-import { Helmet } from "react-helmet";
-import styled from "@emotion/styled";
 
-//Components
-import ReportContent from "../../Content/Report/ReportContent";
-import ReportSubline from "../../Content/Report/ReportSubline";
-import ReportTitle from "../../Content/Report/ReportTitle";
-import ReportEyebrow from "../../Content/Report/ReportEyebrow";
+import createReportPage, {
+  DEFAULT_META_DESCRIPTION,
+} from "./createReportPage";
 
-import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
+const metaTitle =
+  "Four industry shifts making user onboarding & activation indispensible | Alexandros Shomper";
 
-const PageWrapper = styled.div`
-  text-align: left;
-  margin-top: 72px;
-`;
+const renderContent = ({ LeadGenerationForm }) => (
+  <section>
+    <h2>Introduction</h2>
+    <p>
+      In today's challenging startup landscape, acquiring and retaining users
+      has never been more critical – or more difficult. This in-depth report
+      reveals why exceptional user onboarding is no longer optional.
+    </p>
 
-const Section = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  align-self: stretch;
-  flex-grow: 0;
-`;
+    <h3>Our latest report reveals:</h3>
+    <ul>
+      <li>Market dynamics have fundamentally changed.</li>
+      <li>The funding environment has tightened.</li>
+      <li>Product and team structures have evolved.</li>
+      <li>External influences shape internal pressures.</li>
+    </ul>
+    <h3>Key insights you'll discover:</h3>
+    <ul>
+      <li>
+        How market dynamics have fundamentally shifted, making user activation
+        more crucial than ever.
+      </li>
+      <li>
+        Why companies with strong onboarding see up to 86% higher customer
+        lifetime value.
+      </li>
+      <li>
+        The direct link between onboarding quality and key metrics like CAC,
+        CLV, and NRR.
+      </li>
+      <li>Real-world examples and case studies from successful companies.</li>
+    </ul>
 
-const Content = () => {
-  return (
-    <PageWrapper>
-      <Helmet>
-        <meta charSet="utf-8" />
-        <title>
-          Four industry shifts making user onboarding & activation indispensible
-          | Alexandros Shomper
-        </title>
-        <description>
-          For early-stage and growth startup founders, retention is everything.
-          But what if the key to higher retention and ARR isn't just engagement
-          or new features? Our latest whitepaper dives into why user onboarding
-          and activation are the most powerful (and cost-effective) levers for
-          boosting long-term retention and revenue. Discover how optimizing
-          these critical stages can drastically reduce churn, increase customer
-          lifetime value, and accelerate growth. Download the full report to
-          uncover the strategies top SaaS companies use to turn new users into
-          loyal, paying customers.
-        </description>
-      </Helmet>
-      <Section>
-        <ReportEyebrow text={"Report"} color1="#00b8d4" color2="#62ebff" />
-        <ReportTitle
-          headline={
-            "Four industry shifts making user onboarding & activation indispensible"
-          }
-        />
-        <ReportSubline subline="User Onboarding & Activation: a strategic imperative for growth, retention, and survival." />
-        <ReportContent>
-          <section>
-            <h2>Introduction</h2>
-            <p>
-              In today's challenging startup landscape, acquiring and retaining
-              users has never been more critical – or more difficult. This
-              in-depth report reveals why exceptional user onboarding is no
-              longer optional.
-            </p>
+    <h3>Who this report is for</h3>
+    <p>
+      We designed this report for founders of early-stage and growth startups
+      who are:
+    </p>
+    <ul>
+      <li>Startup founders and product leaders seeking sustainable growth.</li>
+      <li>SaaS companies struggling with user retention and activation.</li>
+      <li>Product teams looking to optimize their onboarding experience.</li>
+      <li>Growth managers focused on improving key metrics.</li>
+    </ul>
+    <p>
+      Download now to understand why user onboarding and activation have become
+      the cornerstone of sustainable business growth in today's market.
+    </p>
+    <div data-report-form>
+      <LeadGenerationForm
+        portal={"49351608"}
+        form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
+        size={"M"}
+        successLink="./report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf"
+      />
+    </div>
+  </section>
+);
 
-            <h3>Our latest report reveals:</h3>
-            <ul>
-              <li>Market dynamics have fundamentally changed.</li>
-              <li>The funding environment has tightened.</li>
-              <li>Product and team structures have evolved.</li>
-              <li>External influences shape internal pressures.</li>
-            </ul>
-            <h3>Key insights you'll discover:</h3>
-            <ul>
-              <li>
-                How market dynamics have fundamentally shifted, making user
-                activation more crucial than ever.
-              </li>
-              <li>
-                Why companies with strong onboarding see up to 86% higher
-                customer lifetime value.
-              </li>
-              <li>
-                The direct link between onboarding quality and key metrics like
-                CAC, CLV, and NRR.
-              </li>
-              <li>
-                Real-world examples and case studies from successful companies.
-              </li>
-            </ul>
-
-            <h3>Who this report is for</h3>
-            <p>
-              We designed this report for founders of early-stage and growth
-              startups who are:
-            </p>
-            <ul>
-              <li>
-                Startup founders and product leaders seeking sustainable growth.
-              </li>
-              <li>
-                SaaS companies struggling with user retention and activation.
-              </li>
-              <li>
-                Product teams looking to optimize their onboarding experience.
-              </li>
-              <li>Growth managers focused on improving key metrics.</li>
-            </ul>
-            <p>
-              Download now to understand why user onboarding and activation have
-              become the cornerstone of sustainable business growth in today's
-              market.
-            </p>
-            <div data-report-form>
-              <LeadGenerationForm
-                portal={"49351608"}
-                form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
-                size={"M"}
-                successLink="./report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf"
-              />
-            </div>
-          </section>
-        </ReportContent>
-      </Section>
-    </PageWrapper>
-  );
-};
-
-export default Content;
+export default createReportPage({
+  metaTitle,
+  metaDescription: DEFAULT_META_DESCRIPTION,
+  title: "Four industry shifts making user onboarding & activation indispensible",
+  subline:
+    "User Onboarding & Activation: a strategic imperative for growth, retention, and survival.",
+  renderContent,
+});

--- a/src/components/Pages/Reports/OASaasGrowth.js
+++ b/src/components/Pages/Reports/OASaasGrowth.js
@@ -1,151 +1,104 @@
 import React from "react";
-import { Helmet } from "react-helmet";
-import styled from "@emotion/styled";
 
-//Components
-import ReportContent from "../../Content/Report/ReportContent";
-import ReportSubline from "../../Content/Report/ReportSubline";
-import ReportTitle from "../../Content/Report/ReportTitle";
-import ReportEyebrow from "../../Content/Report/ReportEyebrow";
+import createReportPage, {
+  DEFAULT_META_DESCRIPTION,
+} from "./createReportPage";
 
-import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
+const metaTitle =
+  "Why Onboarding & Activation Are The Ultimate Levers for SaaS Growth | Alexandros Shomper";
 
-const PageWrapper = styled.div`
-  text-align: left;
-  margin-top: 72px;
-`;
+const renderContent = ({ LeadGenerationForm }) => (
+  <section>
+    <h2>Introduction</h2>
+    <p>
+      For early-stage and growth startup founders, the path to sustainable
+      growth isn't just about acquiring new users – it's about keeping them. And
+      the most powerful levers for improving retention and ARR? User Onboarding
+      &amp; Activation.
+    </p>
 
-const Section = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  align-self: stretch;
-  flex-grow: 0;
-`;
+    <h3>Our latest report reveals:</h3>
+    <ul>
+      <li>
+        Why effective onboarding and activation are the most cost-efficient ways
+        to boost retention.
+      </li>
+      <li>
+        The metrics, frameworks, and psychological insights that make onboarding
+        work.
+      </li>
+      <li>
+        Case studies from successful SaaS companies like HubSpot, Slack,
+        Robinhood, and more.
+      </li>
+      <li>
+        How optimizing onboarding &amp; activation impacts critical metrics like
+        CAC:CLV, NRR, and ARR.
+      </li>
+    </ul>
+    <h3>Key Metrics You'll Discover</h3>
+    <ul>
+      <li>
+        Improving user onboarding can boost customer retention by up to 50%
+        <i>(Invesp)</i>.
+      </li>
+      <li>
+        A well-designed onboarding flow can increase revenue by up to 150% over
+        six months.
+      </li>
+      <li>
+        Reducing churn by just 5% can increase profits by up to 95%
+        <i>(Harvard Business Review)</i>.
+      </li>
+    </ul>
 
-const Content = () => {
-  return (
-    <PageWrapper>
-      <Helmet>
-        <meta charSet="utf-8" />
-        <title>
-          Why Onboarding & Activation Are The Ultimate Levers for SaaS Growth |
-          Alexandros Shomper
-        </title>
-        <description>
-          For early-stage and growth startup founders, retention is everything.
-          But what if the key to higher retention and ARR isn't just engagement
-          or new features? Our latest whitepaper dives into why user onboarding
-          and activation are the most powerful (and cost-effective) levers for
-          boosting long-term retention and revenue. Discover how optimizing
-          these critical stages can drastically reduce churn, increase customer
-          lifetime value, and accelerate growth. Download the full report to
-          uncover the strategies top SaaS companies use to turn new users into
-          loyal, paying customers.
-        </description>
-      </Helmet>
-      <Section>
-        <ReportEyebrow text={"Report"} color1="#00b8d4" color2="#62ebff" />
-        <ReportTitle
-          headline={
-            "Why Onboarding & Activation Are The Ultimate Levers for SaaS Growth"
-          }
-        />
-        <ReportSubline subline="User Onboarding & Activation: The Secret to Long-Term Retention & ARR Growth" />
-        <ReportContent>
-          <section>
-            <h2>Introduction</h2>
-            <p>
-              For early-stage and growth startup founders, the path to
-              sustainable growth isn't just about acquiring new users – it's
-              about keeping them. And the most powerful levers for improving
-              retention and ARR? User Onboarding &amp; Activation.
-            </p>
+    <h3>Who this report is for</h3>
+    <p>
+      We designed this report for founders of early-stage and growth startups
+      who are:
+    </p>
+    <ul>
+      <li>
+        Struggling with <strong>high churn</strong> rates and
+        <strong>low user retention</strong>.
+      </li>
+      <li>
+        Finding it <strong>hard to convert free users to paying customers</strong>.
+      </li>
+      <li>
+        Seeking cost-effective ways to <strong>improve retention and revenue growth</strong>.
+      </li>
+      <li>
+        Unsure <strong>how to measure and optimize onboarding</strong> effectiveness.
+      </li>
+      <li>
+        Looking to <strong>improve CAC:CLV</strong> ratios and
+        <strong>accelerate ARR</strong> growth.
+      </li>
+      <li>
+        Building or refining their <strong>product-led growth strategy</strong>.
+      </li>
+    </ul>
+    <p>
+      If you're trying to turn new users into loyal, paying customers, this
+      whitepaper is for you.
+    </p>
+    <div data-report-form>
+      <LeadGenerationForm
+        portal={"49351608"}
+        form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
+        size={"M"}
+        successLink="./report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
+      />
+    </div>
+  </section>
+);
 
-            <h3>Our latest report reveals:</h3>
-            <ul>
-              <li>
-                Why effective onboarding and activation are the most
-                cost-efficient ways to boost retention.
-              </li>
-              <li>
-                The metrics, frameworks, and psychological insights that make
-                onboarding work.
-              </li>
-              <li>
-                Case studies from successful SaaS companies like HubSpot, Slack,
-                Robinhood, and more.
-              </li>
-              <li>
-                How optimizing onboarding &amp; activation impacts critical
-                metrics like CAC:CLV, NRR, and ARR.
-              </li>
-            </ul>
-            <h3>Key Metrics You'll Discover</h3>
-            <ul>
-              <li>
-                Improving user onboarding can boost customer retention by up to
-                50% <i>(Invesp)</i>.
-              </li>
-              <li>
-                A well-designed onboarding flow can increase revenue by up to
-                150% over six months.
-              </li>
-              <li>
-                Reducing churn by just 5% can increase profits by up to 95%
-                <i>(Harvard Business Review)</i>.
-              </li>
-            </ul>
-
-            <h3>Who this report is for</h3>
-            <p>
-              We designed this report for founders of early-stage and growth
-              startups who are:
-            </p>
-            <ul>
-              <li>
-                Struggling with <strong>high churn</strong> rates and
-                <strong>low user retention</strong>.
-              </li>
-              <li>
-                Finding it{" "}
-                <strong>hard to convert free users to paying customers</strong>.
-              </li>
-              <li>
-                Seeking cost-effective ways to{" "}
-                <strong>improve retention and revenue growth</strong>.
-              </li>
-              <li>
-                Unsure <strong>how to measure and optimize onboarding</strong>
-                effectiveness.
-              </li>
-              <li>
-                Looking to <strong>improve CAC:CLV</strong> ratios and
-                <strong>accelerate ARR</strong> growth.
-              </li>
-              <li>
-                Building or refining their{" "}
-                <strong>product-led growth strategy</strong>.
-              </li>
-            </ul>
-            <p>
-              If you're trying to turn new users into loyal, paying customers,
-              this whitepaper is for you.
-            </p>
-            <div data-report-form>
-              <LeadGenerationForm
-                portal={"49351608"}
-                form={"ce820859-2f9e-41bb-a9f8-db512c279fba"}
-                size={"M"}
-                successLink="./report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
-              />
-            </div>
-          </section>
-        </ReportContent>
-      </Section>
-    </PageWrapper>
-  );
-};
-
-export default Content;
+export default createReportPage({
+  metaTitle,
+  metaDescription: DEFAULT_META_DESCRIPTION,
+  title: "Why Onboarding & Activation Are The Ultimate Levers for SaaS Growth",
+  subline:
+    "User Onboarding & Activation: The Secret to Long-Term Retention & ARR Growth",
+  renderContent,
+});

--- a/src/components/Pages/Reports/createReportPage.js
+++ b/src/components/Pages/Reports/createReportPage.js
@@ -1,0 +1,46 @@
+import React from "react";
+
+import ReportTemplate from "./ReportTemplate";
+import ReportContent from "../../Content/Report/ReportContent";
+import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
+
+const DEFAULT_META_DESCRIPTION =
+  "For early-stage and growth startup founders, retention is everything. But what if the key to higher retention and ARR isn't just engagement or new features? Our latest whitepaper dives into why user onboarding and activation are the most powerful (and cost-effective) levers for boosting long-term retention and revenue. Discover how optimizing these critical stages can drastically reduce churn, increase customer lifetime value, and accelerate growth. Download the full report to uncover the strategies top SaaS companies use to turn new users into loyal, paying customers.";
+
+const createReportPage = ({
+  metaTitle,
+  metaDescription = DEFAULT_META_DESCRIPTION,
+  eyebrow,
+  eyebrowColor1,
+  eyebrowColor2,
+  title,
+  subline,
+  renderContent,
+}) => {
+  const ReportPage = () => (
+    <ReportTemplate
+      metaTitle={metaTitle}
+      metaDescription={metaDescription}
+      eyebrow={eyebrow}
+      eyebrowColor1={eyebrowColor1}
+      eyebrowColor2={eyebrowColor2}
+      title={title}
+      subline={subline}
+    >
+      <ReportContent>
+        {typeof renderContent === "function"
+          ? renderContent({ LeadGenerationForm })
+          : null}
+      </ReportContent>
+    </ReportTemplate>
+  );
+
+  if (title) {
+    ReportPage.displayName = `ReportPage(${title})`;
+  }
+
+  return ReportPage;
+};
+
+export default createReportPage;
+export { DEFAULT_META_DESCRIPTION };


### PR DESCRIPTION
## Summary
- introduce a reusable `createReportPage` factory that wraps the shared report layout and lead generation form defaults
- refactor the existing SaaS Growth and Four Industry Shifts report pages to consume the factory, removing duplicated markup and metadata handling

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ce44e00ce4832790a43c7fa73edc5e