### PR TITLE
Fix lead generation report download links

### DIFF
--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -69,7 +69,7 @@ export default createReportPage({
     "User Onboarding & Activation: a strategic imperative for growth, retention, and survival.",
   leadGenerationFormProps: {
     successLink:
-      "./report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf",
+      "/report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf",
   },
   renderContent,
 });

--- a/src/components/Pages/Reports/OASaasGrowth.js
+++ b/src/components/Pages/Reports/OASaasGrowth.js
@@ -97,7 +97,7 @@ export default createReportPage({
     "User Onboarding & Activation: The Secret to Long-Term Retention & ARR Growth",
   leadGenerationFormProps: {
     successLink:
-      "./report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf",
+      "/report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf",
   },
   renderContent,
 });


### PR DESCRIPTION
## Summary
- point report download success links at the site root so they resolve to the PDF assets instead of React routes

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ce6420369c8327841ab3bf42ddf83b