### PR TITLE
Refactor case study page to use shared template

### DIFF
--- a/src/components/Content/Case/CaseContent.js
+++ b/src/components/Content/Case/CaseContent.js
@@ -1,0 +1,166 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+import { Colors, Devices } from "../../DesignSystem";
+
+const StyledCaseContent = styled.article`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  & > * {
+    width: 70%;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 140px;
+    margin-top: 40px;
+  }
+
+  & > *:last-child {
+    margin-bottom: 0;
+  }
+
+  ${Devices.tabletS} {
+    & > * {
+      width: 520px;
+    }
+  }
+
+  ${Devices.tabletM} {
+    & > * {
+      width: 520px;
+    }
+  }
+
+  ${Devices.laptopS} {
+    & > * {
+      width: 650px;
+    }
+  }
+
+  & > [data-case-content="wide"] {
+    width: 100%;
+  }
+
+  & > [data-case-content="full"] {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: "Roboto", sans-serif;
+    font-style: normal;
+    font-weight: 550;
+    color: ${Colors.primaryText.highEmphasis};
+    text-align: left;
+    margin-top: 0;
+    margin-bottom: 16px;
+    width: 100%;
+  }
+
+  h2 {
+    font-size: 28px;
+    font-weight: 500;
+    line-height: 109%;
+
+    ${Devices.tabletS} {
+      font-size: 36px;
+    }
+  }
+
+  h3 {
+    font-size: 30px;
+    font-weight: 500;
+    line-height: 115%;
+    letter-spacing: 0.01em;
+    line-height: 40px;
+    margin-bottom: 8px;
+    -webkit-background-clip: text;
+    background-clip: text;
+  }
+
+  h4 {
+    font-size: 22px;
+    font-weight: 500;
+    line-height: 115%;
+    letter-spacing: 0.01em;
+    line-height: 24px;
+    margin-bottom: 8px;
+  }
+  p {
+    font-family: "Roboto", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 17px;
+    line-height: 1.7499375rem;
+    color: ${Colors.primaryText.highEmphasis};
+    margin-top: 0;
+    margin-bottom: 24px;
+    width: 100%;
+  }
+
+  ul,
+  ol {
+    font-family: "Roboto", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 17px;
+    line-height: 1.7499375rem;
+    color: ${Colors.primaryText.highEmphasis};
+    padding-left: 24px;
+    margin-top: 8px;
+    margin-bottom: 40px;
+    list-style-position: outside;
+    margin-block-start: 21.25px;
+    tab-size: 4;
+    margin-left: 12px;
+    padding-left: 32px;
+    padding-inline-start: 32px;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  li {
+    margin-bottom: 8px;
+  }
+
+  li:last-child {
+    margin-bottom: 0;
+  }
+
+  strong {
+    font-weight: 700;
+  }
+
+  em {
+    font-style: italic;
+  }
+
+  a {
+    color: ${Colors.blue};
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+  }
+  section:last-child {
+    margin-bottom: 80px;
+  }
+  section > *:last-child,
+  div > *:last-child {
+    margin-bottom: 0px;
+  }
+`;
+
+const CaseContent = ({ children }) => {
+  return <StyledCaseContent>{children}</StyledCaseContent>;
+};
+
+export default CaseContent;

--- a/src/components/Pages/CaseStudies/AsanaCaseStudy.js
+++ b/src/components/Pages/CaseStudies/AsanaCaseStudy.js
@@ -1,341 +1,209 @@
-import styled from "@emotion/styled";
 import React from "react";
-import { Helmet } from "react-helmet";
 
-// DESIGN SYSTEM
-import { Colors, Devices } from "../../DesignSystem";
-// CASE STUDY SLIDER
+import createCasePage from "./createCasePage";
 import CaseStudySlider from "../../CaseStudySlider/CaseStudySlider";
 import asanaCaseStudy from "../../../data/casestudies/asanaCaseStudy.json";
 
-//COMPONENTS
-import CaseCopy from "../../Content/Case/CaseCopy";
-import CaseHeadlineThree from "../../Content/Case/CaseHeadlineThree";
 import CaseImage from "../../Content/Case/CaseImage";
 import CaseSectionHead from "../../Content/Case/CaseSectionHead";
-import CaseSublineTwo from "../../Content/Case/CaseSublineTwo";
-import CaseTitle from "../../Content/Case/CaseTitle";
-import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
-
+import FlowCarousel from "../../Content/FlowCarousel/FlowCarousel";
 import BookAnAudit from "../../LeadGen/BookAnAudit";
 
-import FlowCarousel from "../../Content/FlowCarousel/FlowCarousel";
 import asanaFlow from "../../../data/flows/asana.json";
+import { Colors } from "../../DesignSystem";
 
-const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
+const metaTitle =
+  "Asana Case Study – Onboarding and Activation | Alexandros Shomper";
 
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
+const metaDescription =
+  "Digital Anthropologist. Experienced Product-, Service & Business Designer with demonstrated track record of successfully developing meaningful experiences that people love by using emerging technology, solid company purpose, and a strong brand to elevate human experiences and interactions.";
 
-    /* Inside Auto Layout */
-
-    align-self: stretch;
-    flex-grow: 0;
-  `;
-
-  const Paragraph = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 140px;
-  `;
-
-  const CaseUnorderedList = styled.ul`
-    position: static;
-
-    font-family: "Roboto", sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    color: ${Colors.primaryText.highEmphasis};
-
-    list-style-type: none;
-    list-style-image: none;
-
-    list-style-position: outside;
-    padding-left: 0px;
-
-    /* Inside Auto Layout */
-
-    font-size: 24px;
-    line-height: 160%;
-
-    margin: 0 auto;
-    width: 90%;
-
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-
-  const greenArrowStyle = {
-    color: Colors.green,
-    fontWeight: "bold",
-  };
-
-  return (
-    <Content>
-      <Helmet>
-        <meta charSet="utf-8" />
-        <title>myKnauf | Alexandros Shomper</title>
-        <meta
-          name="description"
-          content="Digital Anthropologist. Experienced Product-, Service & Business
-          Designer with demonstrated track record of successfully developing
-          meaningful experiences that people love by using emerging technology,
-          solid company purpose, and a strong brand to elevate human experiences
-          and interactions."
-        />
-        <description></description>
-        <title>Asana Case Study</title>
-      </Helmet>
-      <Section>
-        <CaseTitleEyebrow
-          text={"Case Study"}
-          color1="#00b8d4"
-          color2="#62ebff"
-        />
-        <CaseTitle headline={"Asana – Onboarding and Activation"} />
-        <CaseSectionHead
-          subline={
-            "How positioning for teams & enterprise impacts your segmentation, setup, and plan selection"
-          }
-        />
-
-        <CaseImage imgURL="/img/case_studies/asana/Cover@2x.png" size="M" />
-        <br />
-        <br />
-        <br />
-        <br />
-        <br />
-        <CaseCopy
-          copy={
-            "In this case study we’ll take a look at asana’s onboarding and activation flow."
-          }
-        />
-        <CaseCopy
-          copy={
-            "While we’ve identified two use cases (Personal Task Management and Team Collaboration), the case study reveals a strong bias towards the team use case, occasionally at the expense of individual users."
-          }
-        />
-        <CaseCopy
-          copy={
-            "Asana has clearly positioned itself towards enterprise and team collaboration, which is reflected throughout their user onboarding journey. This strategic focus impacts everything from landing page messaging, signup, to activation metrics."
-          }
-        />
-        <CaseCopy copy={"Let’s take a look."} />
-        <br />
-        <br />
-        <br />
-        <br />
-        <br />
-        {/* <Paragraph>
-          <CaseHeadlineThree headline={"At a glance"} />
-          <CaseUnorderedList>
-            <li>Digital Strategy</li>
-            <li>Information Architecture</li>
-            <li>Roadmap</li>
-            <li>Digital Branding</li>
-          </CaseUnorderedList>
-       </Paragraph>*/}
-
-        <Paragraph>
-          <CaseSectionHead
-            headline={"Audit Walkthrough"}
-            subline={"A step-by-step look at the onboarding journey⁠"}
-          />
-          <CaseStudySlider slides={asanaCaseStudy} />
-        </Paragraph>
-        <Paragraph>
-          <CaseSectionHead
-            headline={"Key Takeaways"}
-            subline={
-              "While Asana offers a strong team-oriented setup with thorough segmentation, it provides little effort payoff for the user and misses personalization opportunities.⁠"
-            }
-          />{" "}
-          <CaseUnorderedList
-            style={{ marginBottom: "24px", listStyleType: "circle" }}
-          >
-            <li>
-              Strong team-oriented setup flow with emphasis on collaboration
-              features
-            </li>
-            <li>Complex but thorough segmentation process during onboarding</li>
-            <li>Activation heavily dependent on team participation</li>
-            <li>
-              Personal users may feel overwhelmed by enterprise-focused features
-            </li>
-          </CaseUnorderedList>
-        </Paragraph>
-        <Paragraph>
-          <CaseSectionHead
-            headline={"Onboarding Flow Evaluation"}
-            subline={
-              "The onboarding process shows both strengths and areas for improvement"
-            }
-          />{" "}
-          <CaseHeadlineThree headline={"Strengths"} />
-          <CaseUnorderedList>
-            <li>
-              <span style={greenArrowStyle}> 👍 </span>
-              Well-designed project setup with visual workspace representation
-            </li>
-            <li>
-              <span style={greenArrowStyle}> 👍 </span>
-              Strong targeting for team collaboration use case
-            </li>
-            <li>
-              <span style={greenArrowStyle}> 👍 </span>
-              Comprehensive feature introduction
-            </li>
-            <li>
-              <span style={greenArrowStyle}> 👍 </span>
-              Flexible trial period approach
-            </li>
-          </CaseUnorderedList>
-          <br />
-          <br />
-          <CaseHeadlineThree headline={"Areas for Improvement"} />
-          <CaseUnorderedList>
-            <li>
-              <span style={greenArrowStyle}>👎 </span>
-              Segmentation data not effectively utilized for personalization
-            </li>
-            <li>
-              <span style={greenArrowStyle}> 👎 </span>
-              Unclear messaging about trial period and feature availability
-            </li>
-            <li>
-              <span style={greenArrowStyle}> 👎 </span>
-              Complex first experience that may overwhelm new users
-            </li>
-            <li>
-              <span style={greenArrowStyle}> 👎 </span>
-              Limited support for personal use case activation
-            </li>
-          </CaseUnorderedList>
-        </Paragraph>
-        <Paragraph>
-          <CaseSectionHead
-            headline={"Recommendations"}
-            subline={
-              "Based on the audit findings, several opportunities for improvement exist"
-            }
-          />{" "}
-          <CaseHeadlineThree headline={"Landingpage"} />
-          <CaseSublineTwo
-            subline={
-              "Strong team-oriented setup flow with emphasis on collaboration features"
-            }
-          />
-          <br />
-          <CaseCopy
-            copy={
-              "Asana is a versatile project management tool that does not want to be put in one specific use."
-            }
-          />
-          <CaseCopy
-            copy={
-              "On the website homepage It positions itself as a tool to connect any type of work with each other. This positioning is mainly focused on the buyer, the exec. They make the decision to purchase asana on a big plan. For the actual users of asana this positioning is very vague. Common for products with versatile use cases and aiming for enterprise customers."
-            }
-          />
-          <CaseCopy
-            copy={
-              "But the exec comes in very late in the funnel. Most likely an Low-Mid level employee is the driving force, researching tools, advocating to their managers, etc."
-            }
-          />
-          <CaseCopy
-            copy={
-              "Which is why asana provides many Landingpages and positionings for the different functions in a corporate. Marketing, Sales, Dev, HR, etc. which they can now afford compared to when they started - because multi-positioning & GTM is complex and costly."
-            }
-          />
-          <CaseImage
-            imgURL="/img/case_studies/asana/Fletch-horizontal-positioning-landingpage.png"
-            size="S"
-          />
-          <CaseCopy copy={"So, what could asana do better? "} />
-          <CaseCopy
-            copy={
-              "On the design side, the above the fold is very monotone. The CTA kind of blend in with the design. If everything has the same color, nothing is emphasized."
-            }
-          />
-          <CaseCopy
-            copy={
-              "I wonder about the engagement and success KPI for the Chatbot, as it is very distracting and overlapping."
-            }
-          />
-          <CaseCopy
-            copy={
-              "But asana could also leverage it’s multi-positioning. It could use the Landingpage as a source for personalizing the onboarding flow. For example reiterating the usp for marketing on the first signup screen when the user came from the marketing Landingpage."
-            }
-          />
-          <CaseHeadlineThree headline={"Segmentation & Profiling"} />
-          <CaseCopy
-            copy={"Move certain profiling questions to post-commitment phase"}
-          />
-          <CaseHeadlineThree headline={"Personalization"} />
-          <CaseCopy
-            copy={
-              "Leverage segmentation data to offer personalized templates and experiences"
-            }
-          />
-          <br />
-          <CaseHeadlineThree headline={"Plan Selection"} />
-          <CaseCopy
-            copy={
-              "Provide clearer communication about trial period and feature limitations"
-            }
-          />
-          <br />
-          <CaseHeadlineThree headline={"Persona & Product Markets Fit"} />
-          <CaseCopy
-            copy={
-              "Create a more streamlined experience for personal users while maintaining team functionality"
-            }
-          />
-          <br />
-          <CaseHeadlineThree headline={"First Experience"} />{" "}
-          <CaseCopy
-            copy={
-              "First screen is overloaded, Personal users may feel overwhelmed by enterprise-focused features"
-            }
-          />
-          <br />
-          <CaseHeadlineThree headline={"Activation"} />{" "}
-          <CaseCopy
-            copy={"Activation heavily dependent on team participation"}
-          />
-          <br />
-        </Paragraph>
-        <Paragraph>
-          <CaseSectionHead headline={"Flow"} />{" "}
-          <FlowCarousel data={asanaFlow} appname={"Asana"} />{" "}
-        </Paragraph>
-        <Paragraph>
-          <BookAnAudit />
-        </Paragraph>
-      </Section>
-    </Content>
-  );
+const greenArrowStyle = {
+  color: Colors.green,
+  fontWeight: "bold",
 };
 
-export default Content;
+const renderContent = () => (
+  <>
+    <section>
+      <CaseImage imgURL="/img/case_studies/asana/Cover@2x.png" size="M" />
+      <p>
+        In this case study we’ll take a look at asana’s onboarding and activation
+        flow.
+      </p>
+      <p>
+        While we’ve identified two use cases (Personal Task Management and Team
+        Collaboration), the case study reveals a strong bias towards the team use
+        case, occasionally at the expense of individual users.
+      </p>
+      <p>
+        Asana has clearly positioned itself towards enterprise and team
+        collaboration, which is reflected throughout their user onboarding
+        journey. This strategic focus impacts everything from landing page
+        messaging, signup, to activation metrics.
+      </p>
+      <p>Let’s take a look.</p>
+    </section>
+
+    <section data-case-content="wide">
+      <CaseSectionHead
+        headline="Audit Walkthrough"
+        subline="A step-by-step look at the onboarding journey⁠"
+      />
+      <CaseStudySlider slides={asanaCaseStudy} />
+    </section>
+
+    <section>
+      <CaseSectionHead
+        headline="Key Takeaways"
+        subline="While Asana offers a strong team-oriented setup with thorough segmentation, it provides little effort payoff for the user and misses personalization opportunities.⁠"
+      />
+      <ul>
+        <li>Strong team-oriented setup flow with emphasis on collaboration features</li>
+        <li>Complex but thorough segmentation process during onboarding</li>
+        <li>Activation heavily dependent on team participation</li>
+        <li>Personal users may feel overwhelmed by enterprise-focused features</li>
+      </ul>
+    </section>
+
+    <section>
+      <CaseSectionHead
+        headline="Onboarding Flow Evaluation"
+        subline="The onboarding process shows both strengths and areas for improvement"
+      />
+      <h3>Strengths</h3>
+      <ul>
+        <li>
+          <span style={greenArrowStyle}> 👍 </span>
+          Well-designed project setup with visual workspace representation
+        </li>
+        <li>
+          <span style={greenArrowStyle}> 👍 </span>
+          Strong targeting for team collaboration use case
+        </li>
+        <li>
+          <span style={greenArrowStyle}> 👍 </span>
+          Comprehensive feature introduction
+        </li>
+        <li>
+          <span style={greenArrowStyle}> 👍 </span>
+          Flexible trial period approach
+        </li>
+      </ul>
+
+      <h3>Areas for Improvement</h3>
+      <ul>
+        <li>
+          <span style={greenArrowStyle}> 👎 </span>
+          Segmentation data not effectively utilized for personalization
+        </li>
+        <li>
+          <span style={greenArrowStyle}> 👎 </span>
+          Unclear messaging about trial period and feature availability
+        </li>
+        <li>
+          <span style={greenArrowStyle}> 👎 </span>
+          Complex first experience that may overwhelm new users
+        </li>
+        <li>
+          <span style={greenArrowStyle}> 👎 </span>
+          Limited support for personal use case activation
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <CaseSectionHead
+        headline="Recommendations"
+        subline="Based on the audit findings, several opportunities for improvement exist"
+      />
+      <h3>Landingpage</h3>
+      <p>
+        Asana is a versatile project management tool that does not want to be
+        put in one specific use.
+      </p>
+      <p>
+        On the website homepage it positions itself as a tool to connect any type
+        of work with each other. This positioning is mainly focused on the buyer,
+        the exec. They make the decision to purchase Asana on a big plan. For the
+        actual users of Asana this positioning is very vague. Common for products
+        with versatile use cases and aiming for enterprise customers.
+      </p>
+      <p>
+        But the exec comes in very late in the funnel. Most likely a low-mid
+        level employee is the driving force, researching tools, advocating to
+        their managers, etc.
+      </p>
+      <p>
+        Which is why Asana provides many landing pages and positionings for the
+        different functions in a corporate. Marketing, Sales, Dev, HR, etc. which
+        they can now afford compared to when they started — because
+        multi-positioning &amp; GTM is complex and costly.
+      </p>
+      <CaseImage
+        imgURL="/img/case_studies/asana/Fletch-horizontal-positioning-landingpage.png"
+        size="S"
+      />
+      <p>So, what could Asana do better?</p>
+      <p>
+        On the design side, the above the fold is very monotone. The CTA kind of
+        blends in with the design. If everything has the same color, nothing is
+        emphasized.
+      </p>
+      <p>
+        I wonder about the engagement and success KPI for the chatbot, as it is
+        very distracting and overlapping.
+      </p>
+      <p>
+        But Asana could also leverage its multi-positioning. It could use the
+        landing page as a source for personalizing the onboarding flow. For
+        example reiterating the USP for marketing on the first signup screen when
+        the user came from the marketing landing page.
+      </p>
+
+      <h3>Segmentation &amp; Profiling</h3>
+      <p>Move certain profiling questions to post-commitment phase.</p>
+
+      <h3>Personalization</h3>
+      <p>Leverage segmentation data to offer personalized templates and experiences.</p>
+
+      <h3>Plan Selection</h3>
+      <p>Provide clearer communication about trial period and feature limitations.</p>
+
+      <h3>Persona &amp; Product Market Fit</h3>
+      <p>
+        Create a more streamlined experience for personal users while maintaining
+        team functionality.
+      </p>
+
+      <h3>First Experience</h3>
+      <p>First screen is overloaded, personal users may feel overwhelmed by enterprise-focused features.</p>
+
+      <h3>Activation</h3>
+      <p>Activation heavily dependent on team participation.</p>
+    </section>
+
+    <section data-case-content="wide">
+      <CaseSectionHead headline="Flow" />
+      <FlowCarousel data={asanaFlow} appname="Asana" />
+    </section>
+
+    <section data-case-content="wide">
+      <BookAnAudit />
+    </section>
+  </>
+);
+
+const AsanaCaseStudy = createCasePage({
+  metaTitle,
+  metaDescription,
+  eyebrow: "Case Study",
+  eyebrowColor1: "#00b8d4",
+  eyebrowColor2: "#62ebff",
+  title: "Asana – Onboarding and Activation",
+  subline:
+    "How positioning for teams & enterprise impacts your segmentation, setup, and plan selection",
+  renderContent,
+});
+
+export default AsanaCaseStudy;

--- a/src/components/Pages/CaseStudies/CaseTemplate.js
+++ b/src/components/Pages/CaseStudies/CaseTemplate.js
@@ -1,0 +1,80 @@
+import styled from "@emotion/styled";
+import React from "react";
+import { Helmet } from "react-helmet";
+
+import CaseTitle from "../../Content/Case/CaseTitle";
+import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
+import CaseSectionHead from "../../Content/Case/CaseSectionHead";
+
+const ContentWrapper = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  align-self: stretch;
+  flex-grow: 0;
+`;
+
+const HeaderSpacing = () => (
+  <>
+    <br />
+    <br />
+    <br />
+    <br />
+    <br />
+  </>
+);
+
+const CaseTemplate = ({
+  metaTitle,
+  metaDescription,
+  eyebrow = "Case Study",
+  eyebrowColor1,
+  eyebrowColor2,
+  title,
+  subline,
+  hero,
+  children,
+}) => {
+  const renderHero = () => {
+    if (typeof hero === "function") {
+      return hero();
+    }
+
+    return hero || null;
+  };
+
+  return (
+    <ContentWrapper>
+      <Helmet>
+        <meta charSet="utf-8" />
+        {metaTitle && <title>{metaTitle}</title>}
+        {metaDescription && (
+          <meta name="description" content={metaDescription} />
+        )}
+      </Helmet>
+      <Section>
+        {eyebrow ? (
+          <CaseTitleEyebrow
+            text={eyebrow}
+            color1={eyebrowColor1}
+            color2={eyebrowColor2}
+          />
+        ) : null}
+        {title ? <CaseTitle headline={title} /> : null}
+        {subline ? <CaseSectionHead subline={subline} /> : null}
+        {renderHero()}
+        <HeaderSpacing />
+        {children}
+      </Section>
+    </ContentWrapper>
+  );
+};
+
+export default CaseTemplate;
+export { HeaderSpacing as CaseHeaderSpacing };

--- a/src/components/Pages/CaseStudies/createCasePage.js
+++ b/src/components/Pages/CaseStudies/createCasePage.js
@@ -1,0 +1,41 @@
+import React from "react";
+
+import CaseTemplate from "./CaseTemplate";
+import CaseContent from "../../Content/Case/CaseContent";
+
+const createCasePage = ({
+  metaTitle,
+  metaDescription,
+  eyebrow,
+  eyebrowColor1,
+  eyebrowColor2,
+  title,
+  subline,
+  hero,
+  renderContent,
+}) => {
+  const CasePage = () => (
+    <CaseTemplate
+      metaTitle={metaTitle}
+      metaDescription={metaDescription}
+      eyebrow={eyebrow}
+      eyebrowColor1={eyebrowColor1}
+      eyebrowColor2={eyebrowColor2}
+      title={title}
+      subline={subline}
+      hero={hero}
+    >
+      <CaseContent>
+        {typeof renderContent === "function" ? renderContent() : null}
+      </CaseContent>
+    </CaseTemplate>
+  );
+
+  if (title) {
+    CasePage.displayName = `CasePage(${title})`;
+  }
+
+  return CasePage;
+};
+
+export default createCasePage;


### PR DESCRIPTION
## Summary
- add a reusable case page template and content wrapper that mirror the report page setup
- refactor the Asana case study page to use the new template and adopt the shared content styles

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ce79a4e24c832798f62df845b82920