### PR TITLE
Ensure lightbox close button remains circular

### DIFF
--- a/src/components/Lightbox/Lightbox.jsx
+++ b/src/components/Lightbox/Lightbox.jsx
@@ -74,7 +74,11 @@ const CloseButton = styled.button`
   margin-left: auto;
   width: 40px;
   height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  flex: 0 0 auto;
   border-radius: 50%;
+  aspect-ratio: 1 / 1;
   border: none;
   background: #000000;
   color: #ffffff;
@@ -82,6 +86,8 @@ const CloseButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
+  padding: 0;
   z-index: 1;
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);


### PR DESCRIPTION
## Summary
- enforce a fixed 1:1 aspect ratio on the lightbox close button so it stays circular when scrolling or resizing
- prevent the button from shrinking by setting minimum dimensions and disabling flex shrink

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cf916e2f5c8327be401a3bea6f9d9c