### PR TITLE
Make report case cards responsive

### DIFF
--- a/src/components/Content/CaseCard/CaseCard.js
+++ b/src/components/Content/CaseCard/CaseCard.js
@@ -30,21 +30,22 @@ const CaseCard = ({
     list-style-type: none;
     text-align: left;
     text-size-adjust: 100%;
-    width: 327px;
+    width: 100%;
+    max-width: 327px;
     -webkit-font-smoothing: antialiased;
     margin: 0px;
 
     ${Devices.tabletS} {
-      width: 100%;
+      max-width: 100%;
     }
     ${Devices.tabletM} {
-      width: 330px;
+      max-width: 330px;
     }
     ${Devices.laptopS} {
-      width: 400px;
+      max-width: 400px;
     }
     ${Devices.laptopM} {
-      width: 558px;
+      max-width: 558px;
     }
   `;
 
@@ -80,6 +81,7 @@ const CaseCard = ({
     cursor: ${comingSoon && "wait"};
     direction: ltr;
     display: block;
+    width: 100%;
     list-style-image: none;
     list-style-position: outside;
     list-style-type: none;
@@ -107,7 +109,8 @@ const CaseCard = ({
     direction: ltr;
     display: flex;
     flex-direction: column;
-    height: 300px;
+    height: auto;
+    min-height: 300px;
     list-style-image: none;
     list-style-position: outside;
     list-style-type: none;
@@ -120,16 +123,16 @@ const CaseCard = ({
     -webkit-box-orient: vertical;
     -webkit-font-smoothing: antialiased;
     ${Devices.tabletS} {
-      height: 300px;
+      min-height: 300px;
     }
     ${Devices.tabletM} {
-      height: 300px;
+      min-height: 300px;
     }
     ${Devices.laptopS} {
-      height: 330px;
+      min-height: 330px;
     }
     ${Devices.laptopM} {
-      height: 400px;
+      min-height: 400px;
     }
   `;
   const CaseCardContent = styled(motion.div)`

--- a/src/components/Content/CaseCard/CaseCardImage.js
+++ b/src/components/Content/CaseCard/CaseCardImage.js
@@ -9,6 +9,7 @@ const CaseCardImage = ({ imgURL, alt, comingSoon }) => {
 
     direction: ltr;
     display: block;
+    position: relative;
 
     width: 100%;
 
@@ -28,8 +29,9 @@ const CaseCardImage = ({ imgURL, alt, comingSoon }) => {
   `;
   const Picture = styled.picture`
     direction: ltr;
-    max-width: 100%;
-    height: 300px;
+    display: block;
+    width: 100%;
+    height: auto;
 
     list-style-image: none;
     list-style-position: outside;
@@ -45,19 +47,14 @@ const CaseCardImage = ({ imgURL, alt, comingSoon }) => {
     background-color: none;
 
     ${Devices.tabletS} {
-      height: auto;
-    }
-    ${Devices.tabletM} {
-    }
-    ${Devices.laptopS} {
-    }
-    ${Devices.laptopM} {
+      width: 100%;
     }
   `;
 
   const imgStyle = {
     width: "100%",
     height: "auto",
+    display: "block",
     opacity: `${comingSoon ? 0.3 : 1}`,
   };
 

--- a/src/components/Pages/Reports/Reports.js
+++ b/src/components/Pages/Reports/Reports.js
@@ -31,37 +31,35 @@ const Content = (props) => {
   `;
 
   const CaseCardGrid = styled.section`
-    margin: 0px 24px 0px 24px;
+    --gap: 24px;
+    box-sizing: border-box;
+    margin: 0 auto;
+    width: 100%;
+    padding: 0 24px;
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
     justify-content: center;
     align-content: center;
-    align-items: center;
-    --gap: 24px;
-    margin-left: calc(-1 * var(--gap));
-    margin-bottom: calc(-1 * var(--gap));
-
-    & > * {
-      margin-left: var(--gap);
-      margin-bottom: var(--gap);
-    }
+    align-items: stretch;
+    gap: var(--gap);
 
     ${Devices.tabletS} {
-      width: 564px;
+      max-width: 564px;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      max-width: 708px;
       flex-direction: row;
-      align-items: center;
+      align-items: stretch;
       justify-content: center;
     }
     ${Devices.laptopS} {
-      width: 852px;
+      max-width: 852px;
     }
     ${Devices.laptopM} {
-      width: 1140px;
+      max-width: 1140px;
       --gap: 12px;
+      gap: var(--gap);
     }
   `;
   const Panels = styled.section`


### PR DESCRIPTION
## Summary
- allow report case cards to size with their container instead of fixed widths
- make the image and article layout fluid so inner content adapts when the cards shrink
- update the report card grid spacing to rely on gap-based layout and avoid overflow on mobile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfa13bb7408327801b6d452b95e9d0