### PR TITLE
refactor: centralize fade-in animations

### DIFF
--- a/src/components/Content/FadeInSection/FadeInSection.js
+++ b/src/components/Content/FadeInSection/FadeInSection.js
@@ -1,0 +1,52 @@
+import React, { useEffect } from "react";
+import { motion } from "framer-motion";
+
+import useFadeInOnView from "../../../hooks/useFadeInOnView";
+
+const FadeInSection = ({
+  children,
+  as,
+  onViewChange,
+  duration,
+  delay,
+  stagger,
+  once,
+  initial,
+  animateTo,
+  threshold,
+  rootMargin,
+  variants,
+  transition,
+  ...rest
+}) => {
+  const hookOptions = {
+    duration,
+    delay,
+    stagger,
+    once,
+    initial,
+    animateTo,
+    threshold,
+    rootMargin,
+    variants,
+    transition,
+  };
+
+  const { ref, animationProps, inView, entry } = useFadeInOnView(hookOptions);
+
+  useEffect(() => {
+    if (onViewChange) {
+      onViewChange(inView, entry);
+    }
+  }, [inView, entry, onViewChange]);
+
+  const MotionComponent = as || motion.div;
+
+  return (
+    <MotionComponent ref={ref} {...animationProps} {...rest}>
+      {children}
+    </MotionComponent>
+  );
+};
+
+export default FadeInSection;

--- a/src/components/Content/FlipCard/FlipCard.js
+++ b/src/components/Content/FlipCard/FlipCard.js
@@ -1,7 +1,5 @@
-import React, { useEffect } from "react";
+import React, { useState } from "react";
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import { useInView } from "react-intersection-observer";
 
 import { Devices, Colors } from "../../DesignSystem";
 
@@ -9,7 +7,7 @@ import FlipCardEyebrow from "./FlipCardEyebrow";
 import FlipCardCopy from "./FlipCardCopy";
 import { mdiPlus } from "@mdi/js";
 import Icon from "@mdi/react";
-import { useState } from "react";
+import FadeInSection from "../FadeInSection/FadeInSection";
 
 const FlipCard = ({
   eyebrow,
@@ -126,39 +124,6 @@ const FlipCard = ({
     }
   `;
 
-  function FadeInWhenVisible({ children }) {
-    const controls = useAnimation();
-    const [ref, inView] = useInView();
-
-    useEffect(() => {
-      if (inView) {
-        controls.start("visible");
-      }
-    }, [controls, inView]);
-
-    return (
-      <motion.div
-        ref={ref}
-        animate={controls}
-        initial="hidden"
-        transition={{ duration: 0.3 }}
-        variants={{
-          visible: {
-            opacity: 1,
-            transition: {
-              staggerChildren: 0.3,
-            },
-          },
-          hidden: {
-            opacity: 0,
-          },
-        }}
-      >
-        {children}
-      </motion.div>
-    );
-  }
-
   const flipCard = (e) => {
     e.preventDefault();
     setIsFlipped(!isFlipped);
@@ -188,9 +153,9 @@ const FlipCard = ({
         )}
         <br />
         {copy && (
-          <FadeInWhenVisible>
+          <FadeInSection stagger={0.3}>
             <FlipCardCopy textArray={copyBack} />{" "}
-          </FadeInWhenVisible>
+          </FadeInSection>
         )}
         {/*jpg && <FlipCardImage jpg={jpg} png={png} webp={webp} />*/}
       </BackContent>

--- a/src/components/Content/Landingpage/Head.js
+++ b/src/components/Content/Landingpage/Head.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import styled from "@emotion/styled";
 
 import { Colors, Devices } from "../../DesignSystem";
@@ -8,39 +8,7 @@ import HeadSubline from "./HeadSubline";
 import HeadDivider from "./HeadDivider";
 
 import ButtonMedium from "../../Button/ButtonMedium";
-
-import { useInView } from "react-intersection-observer";
-import { motion, useAnimation } from "framer-motion";
-
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+import FadeInSection from "../../Content/FadeInSection/FadeInSection";
 
 const Head = ({ divider, headline, subline, cta }) => {
   const Head = styled.div`
@@ -82,7 +50,7 @@ const Head = ({ divider, headline, subline, cta }) => {
     }
   `;
   return (
-    <FadeInWhenVisible>
+    <FadeInSection>
       <Head>
         {divider && <HeadDivider text={divider} />}
         {headline && <HeadHeadline headline={headline} />}
@@ -96,7 +64,7 @@ const Head = ({ divider, headline, subline, cta }) => {
           />
         )}
       </Head>
-    </FadeInWhenVisible>
+    </FadeInSection>
   );
 };
 

--- a/src/components/Pages/Flows/FlowPageTemplate.js
+++ b/src/components/Pages/Flows/FlowPageTemplate.js
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
-import { useInView } from "react-intersection-observer";
 
 import { getFlowMeta } from "../../../data/flows";
 
@@ -17,39 +15,7 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 import CaseCard from "../../Content/CaseCard/CaseCard";
 
 import FlowCarousel from "../../Content/FlowCarousel/FlowCarousel";
-
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+import FadeInSection from "../../Content/FadeInSection/FadeInSection";
 
 const ContentWrapper = styled.div`
   text-align: left;
@@ -149,9 +115,9 @@ const RelatedResourcesWrapper = ({ resources }) => {
       <CaseSectionHead headline={"Related Ressources"} />
       <CaseCardGrid>
         {resources.map((resource) => (
-          <FadeInWhenVisible key={resource.headline}>
+          <FadeInSection stagger={0.3} key={resource.headline}>
             <CaseCard {...resource} />
-          </FadeInWhenVisible>
+          </FadeInSection>
         ))}
       </CaseCardGrid>
     </Paragraph>

--- a/src/components/Pages/Heraklit/Heraklit.js
+++ b/src/components/Pages/Heraklit/Heraklit.js
@@ -1,8 +1,6 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import { useInView } from "react-intersection-observer";
 
 //Components
 import { Devices } from "../../DesignSystem";
@@ -11,38 +9,11 @@ import CaseSectionHead from "../../Content/Case/CaseSectionHead";
 import NFTGallery from "../../Content/NFTGallery/NFTGallery";
 import OpenSeaGallery from "../../Content/NFTGallery/OpenSeaGallery";
 import NFTCollectionAnalytics from "../../Content/NFTCollectionAnalytics/NFTCollectionAnalytics";
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
+import FadeInSection from "../../Content/FadeInSection/FadeInSection";
 
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+const FadeInWhenVisible = (props) => (
+  <FadeInSection stagger={0.3} {...props} />
+);
 
 const Content = (props) => {
   const Content = styled.div`

--- a/src/components/Pages/Home/Home.js
+++ b/src/components/Pages/Home/Home.js
@@ -1,8 +1,5 @@
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
 import React, { useEffect } from "react";
-
-import { useInView } from "react-intersection-observer";
 
 import ReactGA from "react-ga4";
 
@@ -20,6 +17,7 @@ import BusinessCard from "../../Content/BusinessCard/BusinessCard";
 import Checkbox from "../../Checkbox/Checkbox";
 
 import DeliverablesCard from "../../Content/DeliverablesCard/DeliverablesCard";
+import FadeInSection from "../../Content/FadeInSection/FadeInSection";
 
 import { Check, X } from "lucide-react";
 import AccordeonVisual from "../../Content/AccordeonVisual/AccordeonVisual";
@@ -167,79 +165,31 @@ const ROIImprovementValue = styled.div`
   }
 `;
 
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-  const [hasAnimated, setHasAnimated] = React.useState(false);
+const moveUpVariants = {
+  visible: {
+    transition: {
+      when: "beforeChildren",
+    },
+  },
+  hidden: {
+    transition: {
+      when: "afterChildren",
+    },
+  },
+};
 
-  useEffect(() => {
-    if (inView && !hasAnimated) {
-      controls.start("visible");
-      setHasAnimated(true);
-    }
-  }, [controls, inView, hasAnimated]);
+const FadeInWhenVisible = (props) => (
+  <FadeInSection stagger={0.3} {...props} />
+);
 
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
-
-function MoveUpWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-  const [hasAnimated, setHasAnimated] = React.useState(false);
-
-  useEffect(() => {
-    if (inView && !hasAnimated) {
-      controls.start("visible");
-      setHasAnimated(true);
-    }
-  }, [controls, inView, hasAnimated]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.6 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            when: "beforeChildren",
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-          transition: {
-            when: "afterChildren",
-          },
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+const MoveUpWhenVisible = (props) => (
+  <FadeInSection
+    duration={0.6}
+    stagger={0.3}
+    variants={moveUpVariants}
+    {...props}
+  />
+);
 
 const ContentWrapper = styled.div`
   text-align: left;
@@ -1524,7 +1474,7 @@ const Content = (props) => {
     blinkInterval = 0.25; // 0.25 seconds
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     const onKeyDown = (e) => {
       if (e.key === "Escape") {
         setIsLightboxOpen(false);

--- a/src/components/Pages/Portfolio/MyKnauf.js
+++ b/src/components/Pages/Portfolio/MyKnauf.js
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
-import { useInView } from "react-intersection-observer";
 
 //Components
 import { Colors, Devices } from "../../DesignSystem";
@@ -18,39 +16,11 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseCard from "../../Content/CaseCard/CaseCard";
 import Drawer from "../../Content/Drawer/Drawer";
+import FadeInSection from "../../Content/FadeInSection/FadeInSection";
 
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+const FadeInWhenVisible = (props) => (
+  <FadeInSection stagger={0.3} {...props} />
+);
 
 const Content = (props) => {
   const galleryItems = [

--- a/src/components/Pages/Portfolio/Portfolio.js
+++ b/src/components/Pages/Portfolio/Portfolio.js
@@ -1,8 +1,7 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import { useInView } from "react-intersection-observer";
+import FadeInSection from "../../Content/FadeInSection/FadeInSection";
 
 //Components
 import { Devices } from "../../DesignSystem";
@@ -11,38 +10,9 @@ import SectionHead from "../../Content/Section/SectionHead";
 import CaseCard from "../../Content/CaseCard/CaseCard";
 import CaseSectionSummary from "../../Content/Case/CaseSectionSummary";
 
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+const FadeInWhenVisible = (props) => (
+  <FadeInSection stagger={0.3} {...props} />
+);
 
 const Content = (props) => {
   const Content = styled.div`

--- a/src/components/Pages/Profile/Profile.js
+++ b/src/components/Pages/Profile/Profile.js
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
-import { useInView } from "react-intersection-observer";
 import Trend from "react-trend";
 
 //Components
@@ -20,113 +18,42 @@ import ButtonMedium from "../../Button/ButtonMedium";
 import { mdiFilePdfBox } from "@mdi/js";
 import BusinessCard from "../../Content/BusinessCard/BusinessCard";
 import { mdiEmail } from "@mdi/js";
+import FadeInSection from "../../Content/FadeInSection/FadeInSection";
 
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
+const moveUpVariants = {
+  visible: {
+    transition: {
+      when: "beforeChildren",
+    },
+  },
+  hidden: {
+    transition: {
+      when: "afterChildren",
+    },
+  },
+};
 
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
+const FadeInWhenVisible = (props) => (
+  <FadeInSection stagger={0.3} {...props} />
+);
 
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+const MoveUpWhenVisible = (props) => (
+  <FadeInSection
+    duration={0.6}
+    stagger={0.3}
+    variants={moveUpVariants}
+    {...props}
+  />
+);
 
-function MoveUpWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.6 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            when: "beforeChildren",
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-          transition: {
-            when: "afterChildren",
-          },
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
-
-function RevealWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.9 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            when: "beforeChildren",
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-          transition: {
-            when: "afterChildren",
-          },
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+const RevealWhenVisible = (props) => (
+  <FadeInSection
+    duration={0.9}
+    stagger={0.3}
+    variants={moveUpVariants}
+    {...props}
+  />
+);
 
 const Content = (props) => {
   const Content = styled.div`

--- a/src/hooks/useFadeInOnView.js
+++ b/src/hooks/useFadeInOnView.js
@@ -1,0 +1,100 @@
+import { useEffect, useMemo } from "react";
+import { useAnimation } from "framer-motion";
+import { useInView } from "react-intersection-observer";
+
+/**
+ * Shared hook to orchestrate fade-in animations once an element enters the viewport.
+ *
+ * @param {Object} options
+ * @param {number} [options.duration=0.3] - Duration of the root transition.
+ * @param {number} [options.delay=0] - Delay before the root transition starts.
+ * @param {number} [options.stagger] - Value used for variants.visible.transition.staggerChildren.
+ * @param {boolean} [options.once=true] - Whether the animation should only run the first time the element enters the viewport.
+ * @param {string} [options.initial="hidden"] - Initial variant key to use for the motion component.
+ * @param {string} [options.animateTo="visible"] - Variant key to start when the element enters the viewport.
+ * @param {number|number[]} [options.threshold] - Threshold forwarded to the intersection observer.
+ * @param {string} [options.rootMargin] - Root margin forwarded to the intersection observer.
+ * @param {Object} [options.variants] - Variants merged with the default fade behaviour.
+ * @param {Object} [options.transition] - Additional transition values merged with the root transition.
+ */
+const useFadeInOnView = ({
+  duration = 0.3,
+  delay = 0,
+  stagger,
+  once = true,
+  initial = "hidden",
+  animateTo = "visible",
+  threshold,
+  rootMargin,
+  variants,
+  transition,
+} = {}) => {
+  const controls = useAnimation();
+  const [ref, inView, entry] = useInView({
+    triggerOnce: once,
+    threshold,
+    rootMargin,
+  });
+
+  useEffect(() => {
+    if (inView) {
+      controls.start(animateTo);
+    } else if (!once) {
+      controls.start(initial);
+    }
+  }, [controls, inView, animateTo, initial, once]);
+
+  const resolvedTransition = useMemo(() => {
+    const baseTransition = { duration, delay };
+    if (transition) {
+      return { ...baseTransition, ...transition };
+    }
+    return baseTransition;
+  }, [duration, delay, transition]);
+
+  const resolvedVariants = useMemo(() => {
+    const { visible = {}, hidden = {}, ...otherVariants } = variants || {};
+    const { transition: visibleTransition = {}, ...visibleRest } = visible;
+    const { transition: hiddenTransition, ...hiddenRest } = hidden;
+
+    const visibleTransitionWithStagger = {
+      ...visibleTransition,
+      ...(stagger != null ? { staggerChildren: stagger } : {}),
+    };
+
+    const hiddenVariant = {
+      opacity: 0,
+      ...hiddenRest,
+      ...(hiddenTransition ? { transition: hiddenTransition } : {}),
+    };
+
+    const visibleVariant = {
+      opacity: 1,
+      ...visibleRest,
+      ...(Object.keys(visibleTransitionWithStagger).length
+        ? { transition: visibleTransitionWithStagger }
+        : {}),
+    };
+
+    return {
+      hidden: hiddenVariant,
+      visible: visibleVariant,
+      ...otherVariants,
+    };
+  }, [variants, stagger]);
+
+  return {
+    ref,
+    controls,
+    inView,
+    entry,
+    animationProps: {
+      animate: controls,
+      initial,
+      variants: resolvedVariants,
+      transition: resolvedTransition,
+    },
+  };
+};
+
+export default useFadeInOnView;


### PR DESCRIPTION
## Summary
- add a reusable `useFadeInOnView` hook and `FadeInSection` component for viewport-driven fade animations
- update Home, Profile, Portfolio, MyKnauf, Heraklit, Flow template, FlipCard, and Landing Head to consume the shared helper instead of duplicating logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10a1fbca8832787ec88c6f9f96470