### PR TITLE
Refactor section layouts into reusable components

### DIFF
--- a/src/components/Content/CaseCard/CaseCardGrid.js
+++ b/src/components/Content/CaseCard/CaseCardGrid.js
@@ -1,40 +1,7 @@
 import React from "react";
-import styled from "@emotion/styled";
-import { Devices } from "../../DesignSystem";
 
-const CaseCardGrid = (props) => {
-  const CaseCardGrid = styled.section`
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-content: center;
-    align-items: center;
-    align-self: center;
-    --gap: 24px;
-    margin-left: 24px;
-    margin-right: 24px;
-    margin-left: calc(-1 * var(--gap));
-    margin-bottom: calc(-1 * var(--gap));
+import CardGrid from "../Section/CardGrid";
 
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-      flex-direction: row;
-      align-items: center;
-      justify-content: center;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  return <CaseCardGrid></CaseCardGrid>;
-};
+const CaseCardGrid = (props) => <CardGrid {...props} />;
 
 export default CaseCardGrid;

--- a/src/components/Content/Section/CardGrid.js
+++ b/src/components/Content/Section/CardGrid.js
@@ -1,0 +1,65 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import { Devices } from "../../DesignSystem";
+
+const buildResponsiveStyles = (responsive) => {
+  if (!responsive) {
+    return null;
+  }
+
+  return Object.entries(responsive).map(([breakpoint, styles]) => {
+    const mediaQuery = Devices[breakpoint];
+
+    if (!mediaQuery || !styles) {
+      return null;
+    }
+
+    return css`
+      ${mediaQuery} {
+        ${styles}
+      }
+    `;
+  });
+};
+
+const spacingStyles = ({ gap = "24px", spacingStrategy = "gap", bleedRight }) => {
+  if (spacingStrategy === "margins") {
+    return css`
+      --gap: ${gap};
+      margin-left: calc(-1 * var(--gap));
+      margin-bottom: calc(-1 * var(--gap));
+      ${bleedRight ? "margin-right: calc(-1 * var(--gap));" : ""}
+
+      & > * {
+        margin-left: var(--gap);
+        margin-bottom: var(--gap);
+      }
+    `;
+  }
+
+  return css`
+    --gap: ${gap};
+    gap: var(--gap);
+  `;
+};
+
+const CardGrid = styled.section`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: ${({ flexDirection = "column" }) => flexDirection};
+  flex-wrap: ${({ flexWrap = "wrap" }) => flexWrap};
+  justify-content: ${({ justifyContent = "center" }) => justifyContent};
+  align-content: ${({ alignContent = "center" }) => alignContent};
+  align-items: ${({ alignItems = "center" }) => alignItems};
+  align-self: ${({ alignSelf = "auto" }) => alignSelf};
+  margin: ${({ margin = "0px 24px" }) => margin};
+  padding: ${({ padding = "0px" }) => padding};
+  width: ${({ width = "auto" }) => width};
+  max-width: ${({ maxWidth = "none" }) => maxWidth};
+
+  ${(props) => spacingStyles(props)}
+
+  ${({ responsive }) => buildResponsiveStyles(responsive)};
+`;
+
+export default CardGrid;

--- a/src/components/Content/Section/Panels.js
+++ b/src/components/Content/Section/Panels.js
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import { Devices } from "../../DesignSystem";
+
+const buildResponsiveStyles = (responsive) => {
+  if (!responsive) {
+    return null;
+  }
+
+  return Object.entries(responsive).map(([breakpoint, styles]) => {
+    const mediaQuery = Devices[breakpoint];
+
+    if (!mediaQuery || !styles) {
+      return null;
+    }
+
+    return css`
+      ${mediaQuery} {
+        ${styles}
+      }
+    `;
+  });
+};
+
+const Panels = styled.section`
+  display: flex;
+  flex-direction: ${({ flexDirection = "column" }) => flexDirection};
+  flex-wrap: ${({ flexWrap = "wrap" }) => flexWrap};
+  justify-content: ${({ justifyContent = "flex-start" }) => justifyContent};
+  align-content: ${({ alignContent = "center" }) => alignContent};
+  align-items: ${({ alignItems = "flex-start" }) => alignItems};
+  gap: ${({ gap = "12px" }) => gap};
+  margin: ${({ margin = "0px" }) => margin};
+  width: ${({ width = "auto" }) => width};
+  box-sizing: border-box;
+
+  ${({ responsive }) => buildResponsiveStyles(responsive)};
+`;
+
+export default Panels;

--- a/src/components/Content/Section/SectionLayout.js
+++ b/src/components/Content/Section/SectionLayout.js
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+
+const SectionLayout = styled.section`
+  display: flex;
+  flex-direction: ${({ flexDirection = "column" }) => flexDirection};
+  justify-content: ${({ justifyContent = "flex-start" }) => justifyContent};
+  align-items: ${({ alignItems = "center" }) => alignItems};
+  width: ${({ width = "100%" }) => width};
+  box-sizing: border-box;
+  flex: none;
+  align-self: ${({ alignSelf = "stretch" }) => alignSelf};
+  flex-grow: ${({ flexGrow = 0 }) => flexGrow};
+  margin: ${({ margin = "0px" }) => margin};
+  ${({ marginBottom }) =>
+    marginBottom !== undefined
+      ? `margin-bottom: ${marginBottom};`
+      : "margin-bottom: 200px;"}
+  padding: ${({ padding = "0px" }) => padding};
+`;
+
+export default SectionLayout;

--- a/src/components/Pages/CaseStudies/CaseStudies.js
+++ b/src/components/Pages/CaseStudies/CaseStudies.js
@@ -3,90 +3,22 @@ import { Helmet } from "react-helmet";
 import styled from "@emotion/styled";
 
 //Components
-import { Devices } from "../../DesignSystem";
 import SectionHead from "../../Content/Section/SectionHead";
 
 import CaseCard from "../../Content/CaseCard/CaseCard";
 import CaseSectionSummary from "../../Content/Case/CaseSectionSummary";
+import SectionLayout from "../../Content/Section/SectionLayout";
+import CardGrid from "../../Content/Section/CardGrid";
+import Panels from "../../Content/Section/Panels";
+
+const ContentWrapper = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
 
 const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
-
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    flex: none;
-    order: 3;
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 200px;
-  `;
-
-  const CaseCardGrid = styled.section`
-    margin: 0px 24px 0px 24px;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-content: center;
-    align-items: center;
-    --gap: 24px;
-    gap: var(--gap);
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      margin: 0px 0px 0px 0px;
-
-      width: 708px;
-      flex-direction: row;
-      align-items: center;
-      justify-content: center;
-    }
-    ${Devices.laptopS} {
-      width: 864px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-      --gap: 12px;
-    }
-  `;
-  const Panels = styled.section`
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    gap: auto;
-    justify-content: flex-start;
-    align-content: center;
-    align-items: flex-start;
-    gap: 12px;
-
-    margin: 0px;
-    ${Devices.tabletS} {
-      width: 576px;
-    }
-    ${Devices.tabletM} {
-      width: 720px;
-      flex-direction: row;
-    }
-    ${Devices.laptopS} {
-      width: 864px;
-    }
-    ${Devices.laptopM} {
-      width: 1152px;
-    }
-  `;
-
   return (
-    <Content>
+    <ContentWrapper>
       <Helmet>
         <meta charSet="utf-8" />
         <title>Case Studies | Alexandros Shomper</title>
@@ -98,19 +30,45 @@ const Content = (props) => {
           and interactions.
         </description>
       </Helmet>
-      <Section>
+      <SectionLayout>
         <SectionHead
           headline="Case Studies"
           subline="Studies on user onboarding & activation from various products."
         />
-        <Panels style={{ marginBottom: "48px" }}>
+        <Panels
+          margin="0px 0px 48px"
+          responsive={{
+            tabletS: "width: 576px;",
+            tabletM: `
+              width: 720px;
+              flex-direction: row;
+            `,
+            laptopS: "width: 864px;",
+            laptopM: "width: 1152px;",
+          }}
+        >
           <CaseSectionSummary
             copy="
 Detailed use cases assessing the user onboarding & activation flows from different companies and products."
             //imgURL="./img/PanelTestImages/one.jpg"
           />
         </Panels>
-        <CaseCardGrid>
+        <CardGrid
+          responsive={{
+            tabletS: "width: 564px;",
+            tabletM: `
+              width: 708px;
+              flex-direction: row;
+              align-items: center;
+              justify-content: center;
+            `,
+            laptopS: "width: 864px;",
+            laptopM: `
+              width: 1140px;
+              --gap: 12px;
+            `,
+          }}
+        >
           <CaseCard
             eyebrow="Case Study"
             eyebrowColor2="#FFEAED"
@@ -150,9 +108,9 @@ Detailed use cases assessing the user onboarding & activation flows from differe
             imgURL="/img/case_studies/trello/Cover@2x.png"
             comingSoon="true"
           />
-        </CaseCardGrid>
-      </Section>
-    </Content>
+        </CardGrid>
+      </SectionLayout>
+    </ContentWrapper>
   );
 };
 

--- a/src/components/Pages/Flows/FlowPageTemplate.js
+++ b/src/components/Pages/Flows/FlowPageTemplate.js
@@ -15,6 +15,8 @@ import CaseSubline from "../../Content/Case/CaseSubline";
 import CaseTitle from "../../Content/Case/CaseTitle";
 import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 import CaseCard from "../../Content/CaseCard/CaseCard";
+import SectionLayout from "../../Content/Section/SectionLayout";
+import CardGrid from "../../Content/Section/CardGrid";
 
 import FlowCarousel from "../../Content/FlowCarousel/FlowCarousel";
 
@@ -56,58 +58,6 @@ const ContentWrapper = styled.div`
   margin-top: 72px;
 `;
 
-const Section = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  align-self: stretch;
-  flex-grow: 0;
-`;
-
-const Paragraph = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  align-self: stretch;
-  flex-grow: 0;
-  margin-bottom: 140px;
-`;
-
-const CaseCardGrid = styled.section`
-  margin: 0px;
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-content: center;
-  align-items: center;
-  gap: 24px;
-  margin-bottom: calc(-1 * var(--gap));
-
-  & > * {
-    margin-left: var(--gap);
-    margin-bottom: var(--gap);
-  }
-
-  ${Devices.tabletS} {
-    width: 564px;
-  }
-  ${Devices.tabletM} {
-    width: 708px;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-  }
-  ${Devices.laptopS} {
-    width: 852px;
-  }
-  ${Devices.laptopM} {
-    width: 1140px;
-  }
-`;
-
 const Chips = styled.div`
   display: flex;
   flex-direction: row;
@@ -145,16 +95,29 @@ const RelatedResourcesWrapper = ({ resources }) => {
   }
 
   return (
-    <Paragraph>
+    <SectionLayout marginBottom="140px">
       <CaseSectionHead headline={"Related Ressources"} />
-      <CaseCardGrid>
+      <CardGrid
+        margin="0px"
+        responsive={{
+          tabletS: "width: 564px;",
+          tabletM: `
+            width: 708px;
+            flex-direction: row;
+            align-items: center;
+            justify-content: center;
+          `,
+          laptopS: "width: 852px;",
+          laptopM: "width: 1140px;",
+        }}
+      >
         {resources.map((resource) => (
           <FadeInWhenVisible key={resource.headline}>
             <CaseCard {...resource} />
           </FadeInWhenVisible>
         ))}
-      </CaseCardGrid>
-    </Paragraph>
+      </CardGrid>
+    </SectionLayout>
   );
 };
 
@@ -183,7 +146,7 @@ const FlowPageTemplate = ({ flowSlug, screens = [], relatedResources }) => {
         <title>{pageTitle}</title>
         <meta name="description" content={pageDescription} />
       </Helmet>
-      <Section>
+      <SectionLayout marginBottom="0">
         <CaseTitleEyebrow text={"Flow"} color1="#00b8d4" color2="#62ebff" />
         <CaseTitle headline={flowMeta.name} />
         <CaseSubline subline={flowMeta.desc} />
@@ -204,7 +167,7 @@ const FlowPageTemplate = ({ flowSlug, screens = [], relatedResources }) => {
         <br />
         <br />
         <RelatedResourcesWrapper resources={relatedResources} />
-      </Section>
+      </SectionLayout>
     </ContentWrapper>
   );
 };

--- a/src/components/Pages/Flows/Flows.js
+++ b/src/components/Pages/Flows/Flows.js
@@ -3,63 +3,33 @@ import { Helmet } from "react-helmet";
 import styled from "@emotion/styled";
 
 //Components
-import { Devices } from "../../DesignSystem";
 import SectionHead from "../../Content/Section/SectionHead";
 
 import CaseSectionSummary from "../../Content/Case/CaseSectionSummary";
+import SectionLayout from "../../Content/Section/SectionLayout";
+import Panels from "../../Content/Section/Panels";
 //GALLERY
 import GalleryList from "../../Gallery/GalleryList";
 import galleryData from "../../../data/flows";
 
+const ContentWrapper = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
+
+const panelsResponsive = {
+  tabletS: "width: 576px;",
+  tabletM: `
+    width: 720px;
+    flex-direction: row;
+  `,
+  laptopS: "width: 864px;",
+  laptopM: "width: 1152px;",
+};
+
 const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
-
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    flex: none;
-    order: 3;
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 200px;
-  `;
-
-  const Panels = styled.section`
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    gap: auto;
-    justify-content: flex-start;
-    align-content: center;
-    align-items: flex-start;
-    gap: 12px;
-
-    margin: 0px;
-    ${Devices.tabletS} {
-      width: 576px;
-    }
-    ${Devices.tabletM} {
-      width: 720px;
-      flex-direction: row;
-    }
-    ${Devices.laptopS} {
-      width: 864px;
-    }
-    ${Devices.laptopM} {
-      width: 1152px;
-    }
-  `;
-
   return (
-    <Content>
+    <ContentWrapper>
       <Helmet>
         <meta charSet="utf-8" />
         <title>Gallery | Alexandros Shomper</title>
@@ -71,23 +41,23 @@ const Content = (props) => {
           and interactions.
         </description>
       </Helmet>
-      <Section>
+      <SectionLayout>
         <SectionHead
           headline="Flow Gallery"
           subline="A collection of user onboarding & activation flows from your favorite apps."
         />
-        <Panels style={{ marginBottom: "48px" }}>
+        <Panels margin="0 0 48px" responsive={panelsResponsive}>
           <CaseSectionSummary
             copy="
 Detailed use cases assessing the user onboarding & activation flows from different companies and products."
             //imgURL="./img/PanelTestImages/one.jpg"
           />
         </Panels>
-      </Section>
-      <Section>
+      </SectionLayout>
+      <SectionLayout>
         <GalleryList data={galleryData} />
-      </Section>
-    </Content>
+      </SectionLayout>
+    </ContentWrapper>
   );
 };
 

--- a/src/components/Pages/Portfolio/Portfolio.js
+++ b/src/components/Pages/Portfolio/Portfolio.js
@@ -5,11 +5,13 @@ import { motion, useAnimation } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 
 //Components
-import { Devices } from "../../DesignSystem";
 import SectionHead from "../../Content/Section/SectionHead";
 
 import CaseCard from "../../Content/CaseCard/CaseCard";
 import CaseSectionSummary from "../../Content/Case/CaseSectionSummary";
+import SectionLayout from "../../Content/Section/SectionLayout";
+import CardGrid from "../../Content/Section/CardGrid";
+import Panels from "../../Content/Section/Panels";
 
 function FadeInWhenVisible({ children }) {
   const controls = useAnimation();
@@ -44,89 +46,39 @@ function FadeInWhenVisible({ children }) {
   );
 }
 
-const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
+const ContentWrapper = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
 
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
+const panelsResponsive = {
+  tabletS: "width: 576px;",
+  tabletM: `
+    width: 720px;
+    flex-direction: row;
+  `,
+  laptopS: "width: 864px;",
+  laptopM: "width: 1152px;",
+};
+
+const cardGridResponsive = {
+  tabletS: "width: 564px;",
+  tabletM: `
+    width: 708px;
+    flex-direction: row;
     align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    flex: none;
-    order: 3;
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 200px;
-  `;
-
-  const CaseCardGrid = styled.section`
-    margin: 0px 24px 0px 24px;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
     justify-content: center;
-    align-content: center;
-    align-items: center;
-    --gap: 24px;
-    margin-left: calc(-1 * var(--gap));
-    margin-bottom: calc(-1 * var(--gap));
+  `,
+  laptopS: "width: 852px;",
+  laptopM: `
+    width: 1140px;
+    --gap: 12px;
+  `,
+};
 
-    & > * {
-      margin-left: var(--gap);
-      margin-bottom: var(--gap);
-    }
-
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-      flex-direction: row;
-      align-items: center;
-      justify-content: center;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-      --gap: 12px;
-    }
-  `;
-  const Panels = styled.section`
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    gap: auto;
-    justify-content: flex-start;
-    align-content: center;
-    align-items: flex-start;
-    gap: 12px;
-
-    margin: 0px;
-    ${Devices.tabletS} {
-      width: 576px;
-    }
-    ${Devices.tabletM} {
-      width: 720px;
-      flex-direction: row;
-    }
-    ${Devices.laptopS} {
-      width: 864px;
-    }
-    ${Devices.laptopM} {
-      width: 1152px;
-    }
-  `;
-
+const Content = (props) => {
   return (
-    <Content>
+    <ContentWrapper>
       <Helmet>
         <meta charSet="utf-8" />
         <title>Portfolio | Alexandros Shomper</title>
@@ -138,13 +90,13 @@ const Content = (props) => {
           and interactions.
         </description>
       </Helmet>
-      <Section>
+      <SectionLayout>
         <SectionHead
           divider="Selected projects"
           headline="Knauf Construction Apps"
           subline="Building a global apps platform, from scratch."
         />
-        <Panels style={{ marginBottom: "48px" }}>
+        <Panels margin="0 0 48px" responsive={panelsResponsive}>
           <FadeInWhenVisible>
             <CaseSectionSummary
               copy="
@@ -153,7 +105,7 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
             />
           </FadeInWhenVisible>
         </Panels>
-        <CaseCardGrid>
+        <CardGrid spacingStrategy="margins" responsive={cardGridResponsive}>
           <FadeInWhenVisible>
             <CaseCard
               eyebrow="Case Study"
@@ -220,20 +172,15 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
               link="/knauf-orderoverview"
             />
           </FadeInWhenVisible>
-        </CaseCardGrid>
-      </Section>
+        </CardGrid>
+      </SectionLayout>
 
-      <Section>
+      <SectionLayout>
         <SectionHead
           headline="Knauf Corporate Website"
           subline="Unifying the user experience of a global conglomerate."
         />
-        <Panels
-          style={{
-            marginBottom: "48px",
-            gap: "24px",
-          }}
-        >
+        <Panels margin="0 0 48px" gap="24px" responsive={panelsResponsive}>
           <FadeInWhenVisible>
             <CaseSectionSummary
               copy="
@@ -242,7 +189,7 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
             />
           </FadeInWhenVisible>
         </Panels>
-        <CaseCardGrid>
+        <CardGrid spacingStrategy="margins" responsive={cardGridResponsive}>
           <FadeInWhenVisible>
             <CaseCard
               eyebrow="Case Study"
@@ -276,14 +223,14 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               comingSoon="true"
             />
           </FadeInWhenVisible>
-        </CaseCardGrid>
-      </Section>
-      <Section>
+        </CardGrid>
+      </SectionLayout>
+      <SectionLayout>
         <SectionHead
           headline="Occhio Website & eCommerce"
           subline="Leading the digital relaunch of a premium lighting brand."
         />
-        <Panels style={{ marginBottom: "48px" }}>
+        <Panels margin="0 0 48px" responsive={panelsResponsive}>
           <FadeInWhenVisible>
             <CaseSectionSummary
               copy="As the UX Manager & Product Owner, I led Occhio's website relaunch and e-commerce debut, blending brand, user experience and performance to redefine Occhio's digital presence. This overhaul boosted user engagement and conversion rates, earning accolades and raising e-commerce to 10% of revenue share"
@@ -291,7 +238,7 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
             />
           </FadeInWhenVisible>
         </Panels>
-        <CaseCardGrid>
+        <CardGrid spacingStrategy="margins" responsive={cardGridResponsive}>
           <FadeInWhenVisible>
             <CaseCard
               eyebrow="Case Study"
@@ -304,11 +251,11 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               link="/occhio"
             />
           </FadeInWhenVisible>
-        </CaseCardGrid>
-      </Section>
-      <Section>
+        </CardGrid>
+      </SectionLayout>
+      <SectionLayout>
         <SectionHead divider="Side Projects" />
-        <CaseCardGrid>
+        <CardGrid spacingStrategy="margins" responsive={cardGridResponsive}>
           <FadeInWhenVisible>
             <CaseCard
               eyebrow="Website / eCommerce"
@@ -331,9 +278,9 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               link="https://www.cookcook.it/"
             />
           </FadeInWhenVisible>
-        </CaseCardGrid>
-      </Section>
-    </Content>
+        </CardGrid>
+      </SectionLayout>
+    </ContentWrapper>
   );
 };
 

--- a/src/components/Pages/Reports/Reports.js
+++ b/src/components/Pages/Reports/Reports.js
@@ -3,93 +3,22 @@ import { Helmet } from "react-helmet";
 import styled from "@emotion/styled";
 
 //Components
-import { Devices } from "../../DesignSystem";
 import SectionHead from "../../Content/Section/SectionHead";
 
 import CaseCard from "../../Content/CaseCard/CaseCard";
 import CaseSectionSummary from "../../Content/Case/CaseSectionSummary";
+import SectionLayout from "../../Content/Section/SectionLayout";
+import CardGrid from "../../Content/Section/CardGrid";
+import Panels from "../../Content/Section/Panels";
+
+const ContentWrapper = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
 
 const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
-
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    flex: none;
-    order: 3;
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 200px;
-  `;
-
-  const CaseCardGrid = styled.section`
-    --gap: 24px;
-    box-sizing: border-box;
-    margin: 0 auto;
-    width: 100%;
-    padding: 0 24px;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-content: center;
-    align-items: stretch;
-    gap: var(--gap);
-
-    ${Devices.tabletS} {
-      max-width: 564px;
-    }
-    ${Devices.tabletM} {
-      max-width: 708px;
-      flex-direction: row;
-      align-items: stretch;
-      justify-content: center;
-    }
-    ${Devices.laptopS} {
-      max-width: 852px;
-    }
-    ${Devices.laptopM} {
-      max-width: 1140px;
-      --gap: 12px;
-      gap: var(--gap);
-    }
-  `;
-  const Panels = styled.section`
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    gap: auto;
-    justify-content: flex-start;
-    align-content: center;
-    align-items: flex-start;
-    gap: 12px;
-
-    margin: 0px;
-    ${Devices.tabletS} {
-      width: 576px;
-    }
-    ${Devices.tabletM} {
-      width: 720px;
-      flex-direction: row;
-    }
-    ${Devices.laptopS} {
-      width: 864px;
-    }
-    ${Devices.laptopM} {
-      width: 1152px;
-    }
-  `;
-
   return (
-    <Content>
+    <ContentWrapper>
       <Helmet>
         <meta charSet="utf-8" />
         <title>Reports | Alexandros Shomper</title>
@@ -101,18 +30,48 @@ const Content = (props) => {
           and interactions.
         </description>
       </Helmet>
-      <Section>
+      <SectionLayout>
         <SectionHead
           headline="Reports"
           subline="Data and anecdotes from industry research & use cases about user onboarding & activation, user retention, and growth."
         />
-        <Panels style={{ marginBottom: "48px" }}>
+        <Panels
+          margin="0px 0px 48px"
+          responsive={{
+            tabletS: "width: 576px;",
+            tabletM: `
+              width: 720px;
+              flex-direction: row;
+            `,
+            laptopS: "width: 864px;",
+            laptopM: "width: 1152px;",
+          }}
+        >
           <CaseSectionSummary
             copy="In a complex, uncertain and volatile world, the pace of digital change is faster than ever. Looking ahead is critical to success. These reports provide insights into major business and technology trends that will help you stay ahead and make smarter decisions for your organization."
             //imgURL="./img/PanelTestImages/one.jpg"
           />
         </Panels>
-        <CaseCardGrid>
+        <CardGrid
+          margin="0 auto"
+          padding="0 24px"
+          width="100%"
+          alignItems="stretch"
+          responsive={{
+            tabletS: "max-width: 564px;",
+            tabletM: `
+              max-width: 708px;
+              flex-direction: row;
+              align-items: stretch;
+              justify-content: center;
+            `,
+            laptopS: "max-width: 852px;",
+            laptopM: `
+              max-width: 1140px;
+              --gap: 12px;
+            `,
+          }}
+        >
           <CaseCard
             eyebrow="Report"
             eyebrowColor2="#231768"
@@ -132,9 +91,9 @@ const Content = (props) => {
             imgURL="./img/Reports/Cover – [Report] Four industry shifts making User Onboarding & Activation indispensible.png"
             link="/reports/four-indsutry-shifts-making-onboarding-and-activation-indispensible"
           />
-        </CaseCardGrid>
-      </Section>
-    </Content>
+        </CardGrid>
+      </SectionLayout>
+    </ContentWrapper>
   );
 };
 


### PR DESCRIPTION
## Summary
- add SectionLayout, CardGrid, and Panels primitives that accept responsive overrides for spacing and width
- refactor case, report, portfolio, and flow pages to consume the shared layout components
- proxy the legacy CaseCardGrid helper through the new CardGrid implementation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d10a2707488327959eb50fe368971e