### PR TITLE
Refactor navigation into shared base component

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -1,290 +1,72 @@
-import React, { useState, useEffect } from "react";
-import ReactGA from "react-ga4";
+import React from "react";
 import styled from "@emotion/styled";
-import { Link, useLocation } from "react-router-dom";
 
-import { Devices, Colors } from "../DesignSystem";
+import { Colors, Devices } from "../DesignSystem";
 import Identity from "../Identity/Identity";
 import LandingpageMenu from "./LandingpageMenu";
-import { X, Menu } from "lucide-react";
 import ButtonSmallSecondary from "../Button/ButtonSmallSecondary";
-const Navigation = (props) => {
-  const location = useLocation();
-  const currentPath = location.pathname;
-  const [menuOpen, setMenuOpen] = useState(false);
+import NavigationBase from "./NavigationBase";
 
-  //PAGE RELOAD LOGIC
-  useEffect(() => {
-    // Perform actions when the route changes
-    console.log("New page loaded:", location.pathname);
-    setMenuOpen(false);
+const NavigationWrapper = styled.header`
+  margin: 0 auto;
+  height: 220px;
+  width: 100%;
 
-    // Cleanup function to run when the component unmounts
-    return () => {
-      console.log("Component is unmounting");
-    };
-  }, [location]); // Dependency array includes location to trigger effect on route changes
+  z-index: 1000;
+  ${Devices.tabletS} {
+  }
+  ${Devices.tabletM} {
+  }
+  ${Devices.laptopS} {
+  }
+  ${Devices.laptopM} {
+  }
+`;
 
-  //MENU OPEN LOGIC
-  const menuButtonClick = (e) => {
-    console.log("menuButtonClick 1");
-
-    e.preventDefault();
-    setMenuOpen(true);
-    console.log("menuButtonClick 2");
-  };
-  const closeButtonClick = (e) => {
-    console.log("closeButtonClick 1");
-    e.preventDefault();
-    setMenuOpen(false);
-    console.log("closeButtonClick 2");
-  };
-
-  const NavigationWrapper = styled.header`
-   
+const NavigationBar = styled.header`
+  height: 132px;
+  padding-bottom: 72px;
+  border-bottom: 1px solid;
+  border-color: ${Colors.primaryText.highEmphasis};
+  margin-right: 24px;
+  margin-left: 24px;
+  ${Devices.tabletS} {
     margin: 0 auto;
-    height: 220px;
-    width: 100%;
-    
-   
-  
-    z-index: 1000;
-    ${Devices.tabletS} {
-     
-    }
-    ${Devices.tabletM} {
-     
-    }
-    ${Devices.laptopS} {
- 
-    }
-    ${Devices.laptopM} {
-      
-  `;
-  const Navigation = styled.header`
-    height: 132px;
-    padding-bottom: 72px;
-    border-bottom: 1px solid;
-    border-color: ${Colors.primaryText.highEmphasis};
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 852px;
+  }
+  ${Devices.laptopM} {
+    width: 1140px;
+  }
+`;
 
-  const GlobalNavCurtain = styled.div`
-    background: rgba(232, 232, 237, 0.4);
-    -webkit-backdrop-filter: blur(20px);
-    backdrop-filter: blur(20px);
-    visibility: hidden;
-    position: fixed;
-    opacity: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 9998;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-end 80ms;
-    -webkit-backdrop-filter: none;
-    backdrop-filter: none;
-    background: rgba(255, 255, 255, 0.7);
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-start 80ms;
-    backdrop-filter: blur(20px);
-  `;
-
-  const NavigationMenuMobile = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    height: 52px;
-    z-index: 9999;
-
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const CTA = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    padding-top: 15px;
-    gap: 12px;
-    z-index: 9999;
-  `;
-
-  const MenuList = styled.ul`
-    position: fixed;
-    top: 48;
-    left: 0;
-    right: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 0px 24px 0 24px;
-    gap: 16px;
-    z-index: 9999;
-  `;
-
-  const MenuItem = styled.li`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-  const MenuLink = styled(Link)`
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-
-  const MenuButton = styled.div`
-    visibility: visible;
-    display: block;
-
-    ${Devices.tabletS} {
-      visibility: hidden;
-      display: none;
-
-      flex-direction: row;
-      align-items: center;
-    }
-  `;
-  const hanldeBookAudit = (e, href, instance = "navigation-sticky") => {
-    e.preventDefault();
-    ReactGA.event({
-      category: "User",
-      action: "Clicked Book Audit",
-      label: `Book Audit - ${instance}`,
-      value: 10,
-      nonInteraction: false,
-    });
-    setTimeout(() => {
-      window.location.href = href;
-    }, 150);
-    console.log(`Clicked Book Audit - ${instance}`);
-  };
-  return (
-    <NavigationWrapper>
-      {menuOpen ? (
-        <NavigationMenuMobile>
-          <CTA>
-            <MenuButton onClick={closeButtonClick}>
-              {" "}
-              <X size={24} strokeWidth={1} />
-            </MenuButton>
-          </CTA>
-          <MenuList>
-            <MenuItem>
-              <MenuLink
-                to="/case-studies"
-                style={{
-                  color:
-                    currentPath === "/case-studies"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Case Studies
-              </MenuLink>
-            </MenuItem>
-            <MenuItem>
-              <MenuLink
-                to="/reports"
-                style={{
-                  color:
-                    currentPath === "/reports"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Reports
-              </MenuLink>
-            </MenuItem>
-            <MenuItem>
-              <MenuLink
-                to="/flows"
-                style={{
-                  color:
-                    currentPath === "/flows"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Flow Gallery
-              </MenuLink>
-            </MenuItem>
-          </MenuList>
-        </NavigationMenuMobile>
-      ) : (
-        <Navigation>
-          <Identity />
-
-          <CTA>
-            <LandingpageMenu />
-
-            <ButtonSmallSecondary
-              clickAction={(e) =>
-                hanldeBookAudit(
-                  e,
-                  "https://calendar.notion.so/meet/alexandros/onboarding-discovery",
-                  "hero-section"
-                )
-              }
-              text={"Book intro call"}
-              color1={Colors.blue}
-              color2={Colors.blueDark}
-            />
-            <MenuButton onClick={menuButtonClick}>
-              <Menu size={24} strokeWidth={1} />
-            </MenuButton>
-          </CTA>
-        </Navigation>
-      )}
-      {menuOpen && <GlobalNavCurtain />}
-    </NavigationWrapper>
-  );
-};
+const Navigation = () => (
+  <NavigationBase
+    Wrapper={NavigationWrapper}
+    Bar={NavigationBar}
+    renderIdentity={() => <Identity />}
+    renderLandingMenu={() => <LandingpageMenu />}
+    renderCtaButton={({ handleBookAudit }) => (
+      <ButtonSmallSecondary
+        clickAction={(event) =>
+          handleBookAudit(
+            event,
+            "https://calendar.notion.so/meet/alexandros/onboarding-discovery",
+            "hero-section"
+          )
+        }
+        text="Book intro call"
+        color1={Colors.blue}
+        color2={Colors.blueDark}
+      />
+    )}
+    analyticsInstance="navigation"
+  />
+);
 
 export default Navigation;

--- a/src/components/Navigation/NavigationBase.js
+++ b/src/components/Navigation/NavigationBase.js
@@ -1,0 +1,258 @@
+import React, { useCallback, useEffect, useState } from "react";
+import ReactGA from "react-ga4";
+import styled from "@emotion/styled";
+import { Link, useLocation } from "react-router-dom";
+import { Menu, X } from "lucide-react";
+
+import { Colors, Devices } from "../DesignSystem";
+
+const LINKS = [
+  { to: "/case-studies", label: "Case Studies" },
+  { to: "/reports", label: "Reports" },
+  { to: "/flows", label: "Flow Gallery" },
+];
+
+const GlobalNavCurtain = styled.div`
+  background: rgba(232, 232, 237, 0.4);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  visibility: hidden;
+  position: fixed;
+  opacity: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 9998;
+  transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
+    visibility 0.32s step-end 80ms;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  background: rgba(255, 255, 255, 0.7);
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
+    visibility 0.32s step-start 80ms;
+  backdrop-filter: blur(20px);
+`;
+
+const NavigationMenuMobile = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  height: 52px;
+  z-index: 9999;
+
+  margin-right: 24px;
+  margin-left: 24px;
+  ${Devices.tabletS} {
+    margin: 0 auto;
+
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 852px;
+  }
+  ${Devices.laptopM} {
+    width: 1140px;
+  }
+`;
+
+const CTA = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 15px;
+  gap: 12px;
+  z-index: 9999;
+`;
+
+const MenuList = styled.ul`
+  position: fixed;
+  top: 48px;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0px 24px 0 24px;
+  gap: 16px;
+  z-index: 9999;
+`;
+
+const MenuItem = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  line-height: 1.1428571429;
+  font-weight: 600;
+  letter-spacing: 0.007em;
+  text-decoration: none;
+`;
+
+const MenuLink = styled(Link)`
+  font-size: 28px;
+  line-height: 1.1428571429;
+  font-weight: 600;
+  letter-spacing: 0.007em;
+  text-decoration: none;
+`;
+
+const MenuButton = styled.div`
+  visibility: visible;
+  display: block;
+
+  ${Devices.tabletS} {
+    visibility: hidden;
+    display: none;
+
+    flex-direction: row;
+    align-items: center;
+  }
+`;
+
+const useNavigationState = ({ analyticsInstance }) => {
+  const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location]);
+
+  const openMenu = useCallback((event) => {
+    if (event?.preventDefault) {
+      event.preventDefault();
+    }
+    setMenuOpen(true);
+  }, []);
+
+  const closeMenu = useCallback((event) => {
+    if (event?.preventDefault) {
+      event.preventDefault();
+    }
+    setMenuOpen(false);
+  }, []);
+
+  const handleBookAudit = useCallback(
+    (event, href, instanceOverride) => {
+      if (event?.preventDefault) {
+        event.preventDefault();
+      }
+
+      const labelInstance = instanceOverride || analyticsInstance;
+
+      ReactGA.event({
+        category: "User",
+        action: "Clicked Book Audit",
+        label: `Book Audit - ${labelInstance}`,
+        value: 10,
+        nonInteraction: false,
+      });
+
+      setTimeout(() => {
+        window.location.href = href;
+      }, 150);
+    },
+    [analyticsInstance]
+  );
+
+  return {
+    currentPath: location.pathname,
+    menuOpen,
+    openMenu,
+    closeMenu,
+    handleBookAudit,
+  };
+};
+
+const NavigationBase = ({
+  Wrapper,
+  Bar,
+  renderIdentity,
+  renderLandingMenu,
+  renderCtaButton,
+  analyticsInstance,
+  isSticky = false,
+}) => {
+  const {
+    currentPath,
+    menuOpen,
+    openMenu,
+    closeMenu,
+    handleBookAudit,
+  } = useNavigationState({
+    analyticsInstance: analyticsInstance || (isSticky ? "navigation-sticky" : "navigation"),
+  });
+
+  const identity = renderIdentity ? renderIdentity({ isSticky }) : null;
+  const landingMenu = renderLandingMenu
+    ? renderLandingMenu({ isSticky })
+    : null;
+  const ctaButton = renderCtaButton
+    ? renderCtaButton({ handleBookAudit, isSticky })
+    : null;
+
+  return (
+    <Wrapper isSticky={isSticky}>
+      {menuOpen ? (
+        <NavigationMenuMobile>
+          <CTA>
+            <MenuButton onClick={closeMenu}>
+              <X size={24} strokeWidth={1} />
+            </MenuButton>
+          </CTA>
+          <MenuList>
+            {LINKS.map(({ to, label }) => (
+              <MenuItem key={to}>
+                <MenuLink
+                  to={to}
+                  style={{
+                    color:
+                      currentPath === to
+                        ? Colors.primaryText.highEmphasis
+                        : Colors.primaryText.mediumEmphasis,
+                    textDecoration: "none",
+                  }}
+                >
+                  {label}
+                </MenuLink>
+              </MenuItem>
+            ))}
+          </MenuList>
+        </NavigationMenuMobile>
+      ) : (
+        <Bar isSticky={isSticky}>
+          {identity}
+          <CTA>
+            {landingMenu}
+            {ctaButton}
+            <MenuButton onClick={openMenu}>
+              <Menu size={24} strokeWidth={1} />
+            </MenuButton>
+          </CTA>
+        </Bar>
+      )}
+      {menuOpen && <GlobalNavCurtain />}
+    </Wrapper>
+  );
+};
+
+export default NavigationBase;
+
+export {
+  CTA,
+  GlobalNavCurtain,
+  MenuButton,
+  MenuItem,
+  MenuLink,
+  MenuList,
+  NavigationMenuMobile,
+};

--- a/src/components/Navigation/NavigationSticky.js
+++ b/src/components/Navigation/NavigationSticky.js
@@ -1,291 +1,89 @@
-import React, { useState } from "react";
-import ReactGA from "react-ga4";
+import React from "react";
 import styled from "@emotion/styled";
-import { Link, useLocation } from "react-router-dom";
 
-import { Devices, Colors } from "../DesignSystem";
+import { Colors, Devices } from "../DesignSystem";
 import ButtonSmall from "../Button/ButtonSmall";
 import LandingpageMenu from "./LandingpageMenu";
 import IdentitySticky from "../Identity/IdentitySticky";
-import { X, Menu } from "lucide-react";
+import NavigationBase from "./NavigationBase";
 
-const NavigationSticky = (props) => {
-  const location = useLocation();
-  const currentPath = location.pathname;
+const StickyWrapper = styled.header`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  height: 52px;
+  width: 100%;
 
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuButtonClick = (e) => {
-    console.log("menuButtonClick 1");
+  border-bottom: 1px solid;
+  border-color: ${Colors.primaryText.highEmphasis};
+  background-color: ${Colors.background};
 
-    e.preventDefault();
-    setMenuOpen(true);
-    console.log("menuButtonClick 2");
-  };
-  const closeButtonClick = (e) => {
-    console.log("closeButtonClick 1");
-    e.preventDefault();
-    setMenuOpen(false);
-    console.log("closeButtonClick 2");
-  };
+  z-index: 1000;
+  ${Devices.tabletS} {
+  }
+  ${Devices.tabletM} {
+  }
+  ${Devices.laptopS} {
+  }
+  ${Devices.laptopM} {
+  }
+`;
 
-  const NavigationWrapper = styled.header`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+const StickyBar = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  height: 52px;
+
+  border-bottom: 1px solid;
+  border-color: ${Colors.primaryText.highEmphasis};
+  background-color: ${Colors.background};
+  z-index: 1000;
+  margin-right: 24px;
+  margin-left: 24px;
+  ${Devices.tabletS} {
     margin: 0 auto;
-    height: 52px;
-    width: 100%;
-    
-   
-    border-bottom: 1px solid;
-    border-color: ${Colors.primaryText.highEmphasis};
-    background-color: ${Colors.background};
-   
-    z-index: 1000;
-    ${Devices.tabletS} {
-     
-    }
-    ${Devices.tabletM} {
-     
-    }
-    ${Devices.laptopS} {
- 
-    }
-    ${Devices.laptopM} {
-      
-  `;
-  const NavigationSticky = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    height: 52px;
 
-    border-bottom: 1px solid;
-    border-color: ${Colors.primaryText.highEmphasis};
-    background-color: ${Colors.background};
-    z-index: 1000;
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 852px;
+  }
+  ${Devices.laptopM} {
+    width: 1140px;
+  }
+`;
 
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const GlobalNavCurtain = styled.div`
-    background: rgba(232, 232, 237, 0.4);
-    -webkit-backdrop-filter: blur(20px);
-    backdrop-filter: blur(20px);
-    visibility: hidden;
-    position: fixed;
-    opacity: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 9998;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-end 80ms;
-    -webkit-backdrop-filter: none;
-    backdrop-filter: none;
-    background: rgba(255, 255, 255, 0.7);
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-start 80ms;
-    backdrop-filter: blur(20px);
-  `;
-
-  const NavigationMenuMobile = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    height: 52px;
-    z-index: 9999;
-
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const CTA = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    padding-top: 15px;
-    gap: 12px;
-    z-index: 9999;
-  `;
-
-  const MenuList = styled.ul`
-    position: fixed;
-    top: 48;
-    left: 0;
-    right: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 0px 24px 0 24px;
-    gap: 16px;
-    z-index: 9999;
-  `;
-
-  const MenuItem = styled.li`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-  const MenuLink = styled(Link)`
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-
-  const MenuButton = styled.div`
-    visibility: visible;
-    display: block;
-
-    ${Devices.tabletS} {
-      visibility: hidden;
-      display: none;
-
-      flex-direction: row;
-      align-items: center;
-    }
-  `;
-  const hanldeBookAudit = (e, href, instance = "navigation-sticky") => {
-    e.preventDefault();
-    ReactGA.event({
-      category: "User",
-      action: "Clicked Book Audit",
-      label: `Book Audit - ${instance}`,
-      value: 10,
-      nonInteraction: false,
-    });
-    setTimeout(() => {
-      window.location.href = href;
-    }, 150);
-    console.log(`Clicked Book Audit - ${instance}`);
-  };
-  return (
-    <NavigationWrapper>
-      {menuOpen ? (
-        <NavigationMenuMobile>
-          <CTA onClick={closeButtonClick}>
-            <MenuButton>
-              {" "}
-              <X size={24} strokeWidth={1} onClick={closeButtonClick} />
-            </MenuButton>
-          </CTA>
-          <MenuList>
-            <MenuItem>
-              <MenuLink
-                to="/case-studies"
-                style={{
-                  color:
-                    currentPath === "/case-studies"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Case Studies
-              </MenuLink>
-            </MenuItem>
-            <MenuItem>
-              <MenuLink
-                to="/reports"
-                style={{
-                  color:
-                    currentPath === "/reports"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Reports
-              </MenuLink>
-            </MenuItem>
-            <MenuItem>
-              <MenuLink
-                to="/flows"
-                style={{
-                  color:
-                    currentPath === "/flows"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Flow Gallery
-              </MenuLink>
-            </MenuItem>
-          </MenuList>
-        </NavigationMenuMobile>
-      ) : (
-        <NavigationSticky>
-          <IdentitySticky />
-          <CTA>
-            <LandingpageMenu style={{ marginTop: "4px;" }} />
-
-            <ButtonSmall
-              clickAction={(e) =>
-                hanldeBookAudit(
-                  e,
-                  "https://calendar.notion.so/meet/alexandros/onboarding-discovery",
-                  "hero-section"
-                )
-              }
-              text={"Book intro call"}
-              color1={Colors.blue}
-              color2={Colors.blueDark}
-            />
-            <MenuButton onClick={menuButtonClick}>
-              <Menu size={24} strokeWidth={1} />
-            </MenuButton>
-          </CTA>
-        </NavigationSticky>
-      )}
-      {menuOpen && <GlobalNavCurtain />}
-    </NavigationWrapper>
-  );
-};
+const NavigationSticky = () => (
+  <NavigationBase
+    Wrapper={StickyWrapper}
+    Bar={StickyBar}
+    renderIdentity={() => <IdentitySticky />}
+    renderLandingMenu={() => <LandingpageMenu style={{ marginTop: "4px" }} />}
+    renderCtaButton={({ handleBookAudit }) => (
+      <ButtonSmall
+        clickAction={(event) =>
+          handleBookAudit(
+            event,
+            "https://calendar.notion.so/meet/alexandros/onboarding-discovery",
+            "hero-section"
+          )
+        }
+        text="Book intro call"
+        color1={Colors.blue}
+        color2={Colors.blueDark}
+      />
+    )}
+    analyticsInstance="navigation-sticky"
+    isSticky
+  />
+);
 
 export default NavigationSticky;


### PR DESCRIPTION
## Summary
- add `NavigationBase` to encapsulate shared navigation menu state, analytics tracking, and styled primitives
- refactor `Navigation` and `NavigationSticky` to render through the shared base while supplying variant-specific wrappers and identity content

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d10a46cb548327a592d2da709b309a