### PR TITLE
Refine report article layout widths

### DIFF
--- a/src/components/Content/Case/CaseCopy.js
+++ b/src/components/Content/Case/CaseCopy.js
@@ -19,16 +19,19 @@ const CaseCopy = ({ copy }) => {
 
     margin: 0 auto;
     margin-bottom: 40px;
-    width: 90%;
+    width: 100%;
 
     ${Devices.tabletS} {
-      width: 564px;
+      width: 350px;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
+    }
+    ${Devices.laptopM} {
+      width: 567px;
     }
   `;
 

--- a/src/components/Content/Case/CaseHeadline.js
+++ b/src/components/Content/Case/CaseHeadline.js
@@ -13,28 +13,29 @@ const CaseHeadline = ({ headline }) => {
     margin-bottom: 8px;
     margin-top: 0px;
 
-    width: 90%;
+    width: 100%;
 
     font-size: 56px;
     line-height: 109%;
     text-align: left;
     ${Devices.tabletS} {
       text-align: left;
-      width: 564px;
+      width: 350px;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
 
       font-size: 44px;
       line-height: 114%;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
 
       font-size: 80px;
       line-height: 114%;
     }
     ${Devices.laptopM} {
+      width: 567px;
     }
   `;
 

--- a/src/components/Content/Case/CaseHeadlineThree.js
+++ b/src/components/Content/Case/CaseHeadlineThree.js
@@ -30,16 +30,19 @@ const CaseHeadlineThree = ({ headline }) => {
     );
     -webkit-background-clip: text;
     background-clip: text;
-    width: 90%;
+    width: 100%;
 
     ${Devices.tabletS} {
-      width: 564px;
+      width: 350px;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
+    }
+    ${Devices.laptopM} {
+      width: 567px;
     }
   `;
 

--- a/src/components/Content/Case/CaseHeadlineTwo.js
+++ b/src/components/Content/Case/CaseHeadlineTwo.js
@@ -13,23 +13,24 @@ const CaseHeadlineTwo = ({ headline }) => {
     margin-bottom: 8px;
     margin-top: 0px;
 
-    width: 90%;
+    width: 100%;
 
     font-size: 28px;
     line-height: 109%;
     text-align: left;
     ${Devices.tabletS} {
-      width: 564px;
+      width: 350px;
       font-size: 36px;
       line-height: 109%;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
     }
     ${Devices.laptopM} {
+      width: 567px;
     }
   `;
 

--- a/src/components/Content/Case/CaseSectionHead.js
+++ b/src/components/Content/Case/CaseSectionHead.js
@@ -29,15 +29,16 @@ const CaseSectionHead = ({ headline, subline, copy }) => {
     padding-bottom: 60px;
 
     ${Devices.tabletS} {
-      width: 564px;
+      width: 350px;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
     }
     ${Devices.laptopM} {
+      width: 567px;
     }
   `;
   return (

--- a/src/components/Content/Case/CaseSubline.js
+++ b/src/components/Content/Case/CaseSubline.js
@@ -16,19 +16,20 @@ const CaseSubline = ({ subline }) => {
     font-size: 28px;
     line-height: 112%;
     text-align: left;
-    width: 90%;
+    width: 100%;
     ${Devices.tabletS} {
-      width: 564px;
+      width: 350px;
       font-size: 36px;
       line-height: 112%;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
     }
     ${Devices.laptopM} {
+      width: 567px;
     }
   `;
 

--- a/src/components/Content/Case/CaseTitle.js
+++ b/src/components/Content/Case/CaseTitle.js
@@ -30,22 +30,25 @@ const CaseTitle = ({ headline }) => {
     font-weight: 700;
     font-size: 36px;
     line-height: 120%;
-    width: 90%;
+    width: 100%;
 
     color: ${Colors.primaryText};
 
     margin-top: 0px;
 
     ${Devices.tabletS} {
-      width: 564px;
+      width: 350px;
       font-size: 56px;
       line-height: 120%;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
+    }
+    ${Devices.laptopM} {
+      width: 567px;
     }
   `;
 

--- a/src/components/Content/Case/CaseTitleEyebrow.js
+++ b/src/components/Content/Case/CaseTitleEyebrow.js
@@ -36,7 +36,7 @@ const CaseTitleEyebrow = ({ text, color1, color2 }) => {
     font-weight: 700;
     font-size: 16px;
     line-height: 120%;
-    width: 90%;
+    width: 100%;
 
     color: transparent;
     ${csscolor};
@@ -44,13 +44,16 @@ const CaseTitleEyebrow = ({ text, color1, color2 }) => {
     background-clip: text;
 
     ${Devices.tabletS} {
-      width: 564px;
+      width: 350px;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
+    }
+    ${Devices.laptopM} {
+      width: 567px;
     }
   `;
 

--- a/src/components/Content/Case/CaseUnorderedList.js
+++ b/src/components/Content/Case/CaseUnorderedList.js
@@ -18,16 +18,19 @@ const CaseUnorderedList = ({ copy }) => {
     line-height: 142%;
 
     margin: 0 auto;
-    max-width: 90%;
+    max-width: 100%;
 
     ${Devices.tabletS} {
-      width: 564px;
+      width: 350px;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 480px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 567px;
+    }
+    ${Devices.laptopM} {
+      width: 567px;
     }
   `;
 

--- a/src/components/LeadGen/LeadGenerationForm.js
+++ b/src/components/LeadGen/LeadGenerationForm.js
@@ -151,7 +151,7 @@ const ErrorMessage = styled.p`
   margin-top: 8px;
 `;
 const FormWrapper = styled.div`
-  margin: 20px 20px 40px 20px;
+  margin: 20px auto 40px auto;
   padding: 20px;
   border-radius: 0.38rem;
   background-color: white;
@@ -172,17 +172,19 @@ const FormWrapper = styled.div`
   -webkit-box-direction: normal;
   -webkit-font-smoothing: antialiased;
 
-  max-width: 90%;
+  width: 100%;
+  max-width: 100%;
   ${Devices.tabletS} {
-    width: 564px;
+    max-width: 350px;
   }
   ${Devices.tabletM} {
-    width: 708px;
+    max-width: 480px;
   }
   ${Devices.laptopS} {
-    width: 740px;
+    max-width: 567px;
   }
   ${Devices.laptopM} {
+    max-width: 567px;
   }
 `;
 const LeadGenerationForm = ({ portal, form, successLink }) => {

--- a/src/components/Pages/Reports/FourIndustryShifts.js
+++ b/src/components/Pages/Reports/FourIndustryShifts.js
@@ -1,10 +1,7 @@
-import styled from "@emotion/styled";
 import React from "react";
 import { Helmet } from "react-helmet";
 
 //Components
-import { Colors, Devices } from "../../DesignSystem";
-
 import CaseCopy from "../../Content/Case/CaseCopy";
 import CaseHeadlineThree from "../../Content/Case/CaseHeadlineThree";
 import CaseSectionHead from "../../Content/Case/CaseSectionHead";
@@ -13,78 +10,17 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
+import {
+  ReportContent,
+  ReportParagraph,
+  ReportSection,
+  ReportUnorderedList,
+  ReportUnorderedListItem,
+} from "./ReportArticleLayout";
 
-const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
-
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-
-    align-self: stretch;
-    flex-grow: 0;
-  `;
-
-  const Paragraph = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 140px;
-  `;
-
-  const CaseUnorderedList = styled.ul`
-    position: static;
-
-    font-family: "Roboto", sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    color: ${Colors.primaryText.highEmphasis};
-
-    list-style-type: circle;
-    list-style-image: none;
-
-    list-style-position: outside;
-    padding-left: 0px;
-
-    /* Inside Auto Layout */
-
-    font-size: 24px;
-    line-height: 130%;
-
-    margin: 8px auto;
-    width: 90%;
-
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-
-  const CaseUnorderedListItem = styled.li`
-    margin-bottom: 12px;
-  `;
-
+const Content = () => {
   return (
-    <Content>
+    <ReportContent>
       <Helmet>
         <meta charSet="utf-8" />
         <title>
@@ -103,7 +39,7 @@ const Content = (props) => {
           loyal, paying customers.
         </description>
       </Helmet>
-      <Section>
+      <ReportSection>
         <CaseTitleEyebrow text={"Report"} color1="#00b8d4" color2="#62ebff" />
         <CaseTitle
           headline={
@@ -127,44 +63,44 @@ const Content = (props) => {
         />
         <br />
 
-        <Paragraph>
+        <ReportParagraph>
           <CaseHeadlineThree headline={"Our latest report reveals:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
+          <ReportUnorderedList>
+            <ReportUnorderedListItem>
               Market Dynamics Have Fundamentally Changed
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               The Funding Environment Has Tightened
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Product and Team Structures Have Evolved
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               External Influences Shape Internal Pressures
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
+            </ReportUnorderedListItem>
+          </ReportUnorderedList>
           <br />
           <br />
           <CaseHeadlineThree headline={"Key Insights You'll Discover:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
+          <ReportUnorderedList>
+            <ReportUnorderedListItem>
               How market dynamics have fundamentally shifted, making user
               activation more crucial than ever
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Why companies with strong onboarding see up to 86% higher customer
               lifetime value
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               The direct link between onboarding quality and key metrics like
               CAC, CLV, and NRR
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Real-world examples and case studies from successful companies
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-        </Paragraph>
-        <Paragraph>
+            </ReportUnorderedListItem>
+          </ReportUnorderedList>
+        </ReportParagraph>
+        <ReportParagraph>
           <CaseSectionHead
             headline={"Who this report is for"}
             subline={
@@ -172,20 +108,20 @@ const Content = (props) => {
             }
           />
 
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
+          <ReportUnorderedList>
+            <ReportUnorderedListItem>
               Startup founders and product leaders seeking sustainable growth
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               SaaS companies struggling with user retention and activation
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Product teams looking to optimize their onboarding experience
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Growth managers focused on improving key metrics
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
+            </ReportUnorderedListItem>
+          </ReportUnorderedList>
           <br />
           <CaseCopy
             copy={
@@ -200,8 +136,8 @@ const Content = (props) => {
             successLink="./report-docs/[Report] Four industry shifts making onboarding & activation indispensable.pdf"
           />
         </Paragraph>
-      </Section>
-    </Content>
+      </ReportSection>
+    </ReportContent>
   );
 };
 

--- a/src/components/Pages/Reports/OASaasGrowth.js
+++ b/src/components/Pages/Reports/OASaasGrowth.js
@@ -1,10 +1,7 @@
-import styled from "@emotion/styled";
 import React from "react";
 import { Helmet } from "react-helmet";
 
 //Components
-import { Colors, Devices } from "../../DesignSystem";
-
 import CaseCopy from "../../Content/Case/CaseCopy";
 import CaseHeadlineThree from "../../Content/Case/CaseHeadlineThree";
 import CaseSectionHead from "../../Content/Case/CaseSectionHead";
@@ -13,78 +10,17 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseSubline from "../../Content/Case/CaseSubline";
 import LeadGenerationForm from "../../LeadGen/LeadGenerationForm";
+import {
+  ReportContent,
+  ReportParagraph,
+  ReportSection,
+  ReportUnorderedList,
+  ReportUnorderedListItem,
+} from "./ReportArticleLayout";
 
-const Content = (props) => {
-  const Content = styled.div`
-    text-align: left;
-    margin-top: 72px;
-  `;
-
-  const Section = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-
-    align-self: stretch;
-    flex-grow: 0;
-  `;
-
-  const Paragraph = styled.section`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    /* Inside Auto Layout */
-    align-self: stretch;
-    flex-grow: 0;
-    margin-bottom: 140px;
-  `;
-
-  const CaseUnorderedList = styled.ul`
-    position: static;
-
-    font-family: "Roboto", sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    color: ${Colors.primaryText.highEmphasis};
-
-    list-style-type: circle;
-    list-style-image: none;
-
-    list-style-position: outside;
-    padding-left: 0px;
-
-    /* Inside Auto Layout */
-
-    font-size: 24px;
-    line-height: 130%;
-
-    margin: 8px auto;
-    width: 90%;
-
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-
-  const CaseUnorderedListItem = styled.li`
-    margin-bottom: 12px;
-  `;
-
+const Content = () => {
   return (
-    <Content>
+    <ReportContent>
       <Helmet>
         <meta charSet="utf-8" />
         <title>
@@ -103,7 +39,7 @@ const Content = (props) => {
           loyal, paying customers.
         </description>
       </Helmet>
-      <Section>
+      <ReportSection>
         <CaseTitleEyebrow text={"Report"} color1="#00b8d4" color2="#62ebff" />
         <CaseTitle
           headline={
@@ -133,45 +69,45 @@ const Content = (props) => {
           successLink="./reports/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
         />
 
-        <Paragraph>
+        <ReportParagraph>
           <CaseHeadlineThree headline={"Our latest report reveals:"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
+          <ReportUnorderedList>
+            <ReportUnorderedListItem>
               Why effective onboarding and activation are the most
               cost-efficient ways to boost retention.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               The metrics, frameworks, and psychological insights that make
               onboarding work.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Case studies from successful SaaS companies like HubSpot, Slack,
               Robinhood, and more.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               How optimizing onboarding & activation impacts critical metrics
               like CAC:CLV, NRR, and ARR.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
+            </ReportUnorderedListItem>
+          </ReportUnorderedList>
           <br />
           <br />
           <CaseHeadlineThree headline={"Key Metrics You'll Discover"} />
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
+          <ReportUnorderedList>
+            <ReportUnorderedListItem>
               Improving user onboarding can boost customer retention by up to
               50% <i>(Invesp)</i>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               A well-designed onboarding flow can increase revenue by up to 150%
               over six months.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Reducing churn by just 5% can increase profits by up to 95%
               <i>(Harvard Business Review)</i>.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
-        </Paragraph>
-        <Paragraph>
+            </ReportUnorderedListItem>
+          </ReportUnorderedList>
+        </ReportParagraph>
+        <ReportParagraph>
           <CaseSectionHead
             headline={"Who this report is for"}
             subline={
@@ -179,30 +115,30 @@ const Content = (props) => {
             }
           />
 
-          <CaseUnorderedList>
-            <CaseUnorderedListItem>
+          <ReportUnorderedList>
+            <ReportUnorderedListItem>
               Struggling with <b>high churn</b> rates and{" "}
               <b>low user retention</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Finding it <b>hard to convert free users to paying customers</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Seeking cost-effective ways to{" "}
               <b>improve retention and revenue growth</b>.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Unsure <b>how to measure and optimize onboarding</b>{" "}
               effectiveness.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Looking to <b>improve CAC:CLV</b> ratios and <b>accelerate ARR</b>
               growth.
-            </CaseUnorderedListItem>
-            <CaseUnorderedListItem>
+            </ReportUnorderedListItem>
+            <ReportUnorderedListItem>
               Building or refining their <b>product-led growth strategy</b>.
-            </CaseUnorderedListItem>
-          </CaseUnorderedList>
+            </ReportUnorderedListItem>
+          </ReportUnorderedList>
           <br />
           <CaseCopy
             copy={
@@ -216,9 +152,9 @@ const Content = (props) => {
             size={"M"}
             successLink="./report-docs/[Report]Why-Onboarding&Activation-Are-The-Ultimate-Levers-For-SaaS-Growth.pdf"
           />
-        </Paragraph>
-      </Section>
-    </Content>
+        </ReportParagraph>
+      </ReportSection>
+    </ReportContent>
   );
 };
 

--- a/src/components/Pages/Reports/ReportArticleLayout.js
+++ b/src/components/Pages/Reports/ReportArticleLayout.js
@@ -1,0 +1,96 @@
+import styled from "@emotion/styled";
+
+import { Colors, Devices } from "../../DesignSystem";
+
+export const ReportContent = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
+
+export const ReportSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  align-self: stretch;
+  flex-grow: 0;
+  padding: 0 24px;
+  margin: 0 auto;
+
+  ${Devices.tabletS} {
+    padding: 0;
+    width: 350px;
+  }
+  ${Devices.tabletM} {
+    width: 480px;
+  }
+  ${Devices.laptopS} {
+    width: 567px;
+  }
+  ${Devices.laptopM} {
+    width: 567px;
+  }
+`;
+
+export const ReportParagraph = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  align-self: stretch;
+  flex-grow: 0;
+  margin-bottom: 140px;
+  margin-left: auto;
+  margin-right: auto;
+
+  ${Devices.tabletS} {
+    width: 350px;
+  }
+  ${Devices.tabletM} {
+    width: 480px;
+  }
+  ${Devices.laptopS} {
+    width: 567px;
+  }
+  ${Devices.laptopM} {
+    width: 567px;
+  }
+`;
+
+export const ReportUnorderedList = styled.ul`
+  position: static;
+
+  font-family: "Roboto", sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  color: ${Colors.primaryText.highEmphasis};
+
+  list-style-type: circle;
+  list-style-image: none;
+
+  list-style-position: outside;
+  padding-left: 0px;
+
+  font-size: 24px;
+  line-height: 130%;
+
+  margin: 8px auto;
+  width: 100%;
+
+  ${Devices.tabletS} {
+    width: 350px;
+  }
+  ${Devices.tabletM} {
+    width: 480px;
+  }
+  ${Devices.laptopS} {
+    width: 567px;
+  }
+  ${Devices.laptopM} {
+    width: 567px;
+  }
+`;
+
+export const ReportUnorderedListItem = styled.li`
+  margin-bottom: 12px;
+`;


### PR DESCRIPTION
## Summary
- add shared report article layout components that enforce the 100%/350px/480px/567px widths and reuse them across both report pages
- swap the report pages to the new report components so headlines, content blocks and bullet lists respect the narrower column and naming
- align the case headline and lead generation form wrapper widths with the requested breakpoints so all report content matches

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d2bf9eae548327a16e405f314bef2f