### PR TITLE
Refactor navigation shared components

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -1,273 +1,79 @@
-import React, { useState, useEffect } from "react";
-import ReactGA from "react-ga4";
+import React from "react";
 import styled from "@emotion/styled";
-import { Link, useLocation } from "react-router-dom";
+import { Menu, X } from "lucide-react";
 
-import { Devices, Colors } from "../DesignSystem";
+import { Colors } from "../DesignSystem";
 import Identity from "../Identity/Identity";
-import LandingpageMenu from "./LandingpageMenu";
-import { X, Menu } from "lucide-react";
 import { ButtonSmallSecondary } from "../Button";
-const Navigation = (props) => {
-  const location = useLocation();
-  const currentPath = location.pathname;
-  const [menuOpen, setMenuOpen] = useState(false);
+import LandingpageMenu from "./LandingpageMenu";
+import {
+  CTA,
+  GlobalNavCurtain,
+  MenuButton,
+  MenuItem,
+  MenuLink,
+  MenuList,
+  NavigationInnerBase,
+  NavigationMenuMobile,
+  NavigationWrapperBase,
+  handleBookAudit,
+  navLinks,
+  useNavigationMenu,
+} from "./shared";
 
-  //PAGE RELOAD LOGIC
-  useEffect(() => {
-    // Perform actions when the route changes
-    console.log("New page loaded:", location.pathname);
-    setMenuOpen(false);
+const NavigationWrapper = styled(NavigationWrapperBase)`
+  height: 220px;
+`;
 
-    // Cleanup function to run when the component unmounts
-    return () => {
-      console.log("Component is unmounting");
-    };
-  }, [location]); // Dependency array includes location to trigger effect on route changes
+const NavigationContainer = styled(NavigationInnerBase)`
+  height: 132px;
+  padding-bottom: 72px;
+  border-bottom: 1px solid;
+  border-color: ${Colors.primaryText.highEmphasis};
+`;
 
-  //MENU OPEN LOGIC
-  const menuButtonClick = (e) => {
-    console.log("menuButtonClick 1");
+const Navigation = () => {
+  const { menuOpen, currentPath, openMenu, closeMenu } = useNavigationMenu();
 
-    e.preventDefault();
-    setMenuOpen(true);
-    console.log("menuButtonClick 2");
-  };
-  const closeButtonClick = (e) => {
-    console.log("closeButtonClick 1");
-    e.preventDefault();
-    setMenuOpen(false);
-    console.log("closeButtonClick 2");
-  };
-
-  const NavigationWrapper = styled.header`
-   
-    margin: 0 auto;
-    height: 220px;
-    width: 100%;
-    
-   
-  
-    z-index: 1000;
-    ${Devices.tabletS} {
-     
-    }
-    ${Devices.tabletM} {
-     
-    }
-    ${Devices.laptopS} {
- 
-    }
-    ${Devices.laptopM} {
-      
-  `;
-  const Navigation = styled.header`
-    height: 132px;
-    padding-bottom: 72px;
-    border-bottom: 1px solid;
-    border-color: ${Colors.primaryText.highEmphasis};
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const GlobalNavCurtain = styled.div`
-    background: rgba(232, 232, 237, 0.4);
-    -webkit-backdrop-filter: blur(20px);
-    backdrop-filter: blur(20px);
-    visibility: hidden;
-    position: fixed;
-    opacity: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 9998;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-end 80ms;
-    -webkit-backdrop-filter: none;
-    backdrop-filter: none;
-    background: rgba(255, 255, 255, 0.7);
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-start 80ms;
-    backdrop-filter: blur(20px);
-  `;
-
-  const NavigationMenuMobile = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    height: 52px;
-    z-index: 9999;
-
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const CTA = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    padding-top: 15px;
-    gap: 12px;
-    z-index: 9999;
-  `;
-
-  const MenuList = styled.ul`
-    position: fixed;
-    top: 48;
-    left: 0;
-    right: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 0px 24px 0 24px;
-    gap: 16px;
-    z-index: 9999;
-  `;
-
-  const MenuItem = styled.li`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-  const MenuLink = styled(Link)`
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-
-  const MenuButton = styled.div`
-    visibility: visible;
-    display: block;
-
-    ${Devices.tabletS} {
-      visibility: hidden;
-      display: none;
-
-      flex-direction: row;
-      align-items: center;
-    }
-  `;
-  const hanldeBookAudit = (e, href, instance = "navigation-sticky") => {
-    e.preventDefault();
-    ReactGA.event({
-      category: "User",
-      action: "Clicked Book Audit",
-      label: `Book Audit - ${instance}`,
-      value: 10,
-      nonInteraction: false,
-    });
-    setTimeout(() => {
-      window.location.href = href;
-    }, 150);
-    console.log(`Clicked Book Audit - ${instance}`);
-  };
   return (
     <NavigationWrapper>
       {menuOpen ? (
         <NavigationMenuMobile>
           <CTA>
-            <MenuButton onClick={closeButtonClick}>
-              {" "}
+            <MenuButton onClick={closeMenu}>
               <X size={24} strokeWidth={1} />
             </MenuButton>
           </CTA>
           <MenuList>
-            <MenuItem>
-              <MenuLink
-                to="/case-studies"
-                style={{
-                  color:
-                    currentPath === "/case-studies"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Case Studies
-              </MenuLink>
-            </MenuItem>
-            <MenuItem>
-              <MenuLink
-                to="/reports"
-                style={{
-                  color:
-                    currentPath === "/reports"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Reports
-              </MenuLink>
-            </MenuItem>
-            <MenuItem>
-              <MenuLink
-                to="/flows"
-                style={{
-                  color:
-                    currentPath === "/flows"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Flow Gallery
-              </MenuLink>
-            </MenuItem>
+            {navLinks.map(({ to, label }) => (
+              <MenuItem key={to}>
+                <MenuLink
+                  to={to}
+                  style={{
+                    color:
+                      currentPath === to
+                        ? Colors.primaryText.highEmphasis
+                        : Colors.primaryText.mediumEmphasis,
+                    textDecoration: "none",
+                  }}
+                >
+                  {label}
+                </MenuLink>
+              </MenuItem>
+            ))}
           </MenuList>
         </NavigationMenuMobile>
       ) : (
-        <Navigation>
+        <NavigationContainer>
           <Identity />
 
           <CTA>
             <LandingpageMenu />
 
             <ButtonSmallSecondary
-              clickAction={(e) =>
-                hanldeBookAudit(
-                  e,
+              clickAction={(event) =>
+                handleBookAudit(
+                  event,
                   "https://calendar.notion.so/meet/alexandros/onboarding-discovery",
                   "hero-section"
                 )
@@ -276,11 +82,11 @@ const Navigation = (props) => {
               color1={Colors.blue}
               color2={Colors.blueDark}
             />
-            <MenuButton onClick={menuButtonClick}>
+            <MenuButton onClick={openMenu}>
               <Menu size={24} strokeWidth={1} />
             </MenuButton>
           </CTA>
-        </Navigation>
+        </NavigationContainer>
       )}
       {menuOpen && <GlobalNavCurtain />}
     </NavigationWrapper>

--- a/src/components/Navigation/NavigationSticky.js
+++ b/src/components/Navigation/NavigationSticky.js
@@ -1,274 +1,91 @@
-import React, { useState } from "react";
-import ReactGA from "react-ga4";
+import React from "react";
 import styled from "@emotion/styled";
-import { Link, useLocation } from "react-router-dom";
+import { Menu, X } from "lucide-react";
 
-import { Devices, Colors } from "../DesignSystem";
 import { ButtonSmall } from "../Button";
-import LandingpageMenu from "./LandingpageMenu";
+import { Colors } from "../DesignSystem";
 import IdentitySticky from "../Identity/IdentitySticky";
-import { X, Menu } from "lucide-react";
+import LandingpageMenu from "./LandingpageMenu";
+import {
+  CTA,
+  GlobalNavCurtain,
+  MenuButton,
+  MenuItem,
+  MenuLink,
+  MenuList,
+  NavigationInnerBase,
+  NavigationMenuMobile,
+  NavigationWrapperBase,
+  handleBookAudit,
+  navLinks,
+  useNavigationMenu,
+} from "./shared";
 
-const NavigationSticky = (props) => {
-  const location = useLocation();
-  const currentPath = location.pathname;
+const NavigationWrapper = styled(NavigationWrapperBase)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  height: 52px;
+  border-bottom: 1px solid;
+  border-color: ${Colors.primaryText.highEmphasis};
+  background-color: ${Colors.background};
+`;
 
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuButtonClick = (e) => {
-    console.log("menuButtonClick 1");
+const NavigationContainer = styled(NavigationInnerBase)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  height: 52px;
+  border-bottom: 1px solid;
+  border-color: ${Colors.primaryText.highEmphasis};
+  background-color: ${Colors.background};
+`;
 
-    e.preventDefault();
-    setMenuOpen(true);
-    console.log("menuButtonClick 2");
-  };
-  const closeButtonClick = (e) => {
-    console.log("closeButtonClick 1");
-    e.preventDefault();
-    setMenuOpen(false);
-    console.log("closeButtonClick 2");
-  };
+const NavigationSticky = () => {
+  const { menuOpen, currentPath, openMenu, closeMenu } = useNavigationMenu();
 
-  const NavigationWrapper = styled.header`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    height: 52px;
-    width: 100%;
-    
-   
-    border-bottom: 1px solid;
-    border-color: ${Colors.primaryText.highEmphasis};
-    background-color: ${Colors.background};
-   
-    z-index: 1000;
-    ${Devices.tabletS} {
-     
-    }
-    ${Devices.tabletM} {
-     
-    }
-    ${Devices.laptopS} {
- 
-    }
-    ${Devices.laptopM} {
-      
-  `;
-  const NavigationSticky = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    height: 52px;
-
-    border-bottom: 1px solid;
-    border-color: ${Colors.primaryText.highEmphasis};
-    background-color: ${Colors.background};
-    z-index: 1000;
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const GlobalNavCurtain = styled.div`
-    background: rgba(232, 232, 237, 0.4);
-    -webkit-backdrop-filter: blur(20px);
-    backdrop-filter: blur(20px);
-    visibility: hidden;
-    position: fixed;
-    opacity: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 9998;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-end 80ms;
-    -webkit-backdrop-filter: none;
-    backdrop-filter: none;
-    background: rgba(255, 255, 255, 0.7);
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-start 80ms;
-    backdrop-filter: blur(20px);
-  `;
-
-  const NavigationMenuMobile = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    height: 52px;
-    z-index: 9999;
-
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const CTA = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    padding-top: 15px;
-    gap: 12px;
-    z-index: 9999;
-  `;
-
-  const MenuList = styled.ul`
-    position: fixed;
-    top: 48;
-    left: 0;
-    right: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 0px 24px 0 24px;
-    gap: 16px;
-    z-index: 9999;
-  `;
-
-  const MenuItem = styled.li`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-  const MenuLink = styled(Link)`
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-
-  const MenuButton = styled.div`
-    visibility: visible;
-    display: block;
-
-    ${Devices.tabletS} {
-      visibility: hidden;
-      display: none;
-
-      flex-direction: row;
-      align-items: center;
-    }
-  `;
-  const hanldeBookAudit = (e, href, instance = "navigation-sticky") => {
-    e.preventDefault();
-    ReactGA.event({
-      category: "User",
-      action: "Clicked Book Audit",
-      label: `Book Audit - ${instance}`,
-      value: 10,
-      nonInteraction: false,
-    });
-    setTimeout(() => {
-      window.location.href = href;
-    }, 150);
-    console.log(`Clicked Book Audit - ${instance}`);
-  };
   return (
     <NavigationWrapper>
       {menuOpen ? (
         <NavigationMenuMobile>
-          <CTA onClick={closeButtonClick}>
+          <CTA onClick={closeMenu}>
             <MenuButton>
-              {" "}
-              <X size={24} strokeWidth={1} onClick={closeButtonClick} />
+              <X size={24} strokeWidth={1} onClick={closeMenu} />
             </MenuButton>
           </CTA>
           <MenuList>
-            <MenuItem>
-              <MenuLink
-                to="/case-studies"
-                style={{
-                  color:
-                    currentPath === "/case-studies"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Case Studies
-              </MenuLink>
-            </MenuItem>
-            <MenuItem>
-              <MenuLink
-                to="/reports"
-                style={{
-                  color:
-                    currentPath === "/reports"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Reports
-              </MenuLink>
-            </MenuItem>
-            <MenuItem>
-              <MenuLink
-                to="/flows"
-                style={{
-                  color:
-                    currentPath === "/flows"
-                      ? Colors.primaryText.highEmphasis
-                      : Colors.primaryText.mediumEmphasis,
-                  textDecoration: "none",
-                }}
-              >
-                Flow Gallery
-              </MenuLink>
-            </MenuItem>
+            {navLinks.map(({ to, label }) => (
+              <MenuItem key={to}>
+                <MenuLink
+                  to={to}
+                  style={{
+                    color:
+                      currentPath === to
+                        ? Colors.primaryText.highEmphasis
+                        : Colors.primaryText.mediumEmphasis,
+                    textDecoration: "none",
+                  }}
+                >
+                  {label}
+                </MenuLink>
+              </MenuItem>
+            ))}
           </MenuList>
         </NavigationMenuMobile>
       ) : (
-        <NavigationSticky>
+        <NavigationContainer>
           <IdentitySticky />
           <CTA>
-            <LandingpageMenu style={{ marginTop: "4px;" }} />
+            <LandingpageMenu style={{ marginTop: "4px" }} />
 
             <ButtonSmall
-              clickAction={(e) =>
-                hanldeBookAudit(
-                  e,
+              clickAction={(event) =>
+                handleBookAudit(
+                  event,
                   "https://calendar.notion.so/meet/alexandros/onboarding-discovery",
                   "hero-section"
                 )
@@ -277,11 +94,11 @@ const NavigationSticky = (props) => {
               color1={Colors.blue}
               color2={Colors.blueDark}
             />
-            <MenuButton onClick={menuButtonClick}>
+            <MenuButton onClick={openMenu}>
               <Menu size={24} strokeWidth={1} />
             </MenuButton>
           </CTA>
-        </NavigationSticky>
+        </NavigationContainer>
       )}
       {menuOpen && <GlobalNavCurtain />}
     </NavigationWrapper>

--- a/src/components/Navigation/shared.js
+++ b/src/components/Navigation/shared.js
@@ -1,0 +1,202 @@
+import ReactGA from "react-ga4";
+import styled from "@emotion/styled";
+import { Link, useLocation } from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
+
+import { Devices } from "../DesignSystem";
+
+export const navLinks = [
+  { to: "/case-studies", label: "Case Studies" },
+  { to: "/reports", label: "Reports" },
+  { to: "/flows", label: "Flow Gallery" },
+];
+
+export const NavigationWrapperBase = styled.header`
+  margin: 0 auto;
+  width: 100%;
+  z-index: 1000;
+`;
+
+export const NavigationInnerBase = styled.div`
+  margin-right: 24px;
+  margin-left: 24px;
+  ${Devices.tabletS} {
+    margin: 0 auto;
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 852px;
+  }
+  ${Devices.laptopM} {
+    width: 1140px;
+  }
+`;
+
+export const GlobalNavCurtain = styled.div`
+  background: rgba(232, 232, 237, 0.4);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  visibility: hidden;
+  position: fixed;
+  opacity: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 9998;
+  transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
+    visibility 0.32s step-end 80ms;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  background: rgba(255, 255, 255, 0.7);
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
+    visibility 0.32s step-start 80ms;
+  backdrop-filter: blur(20px);
+`;
+
+export const NavigationMenuMobile = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  height: 52px;
+  z-index: 9999;
+
+  margin-right: 24px;
+  margin-left: 24px;
+  ${Devices.tabletS} {
+    margin: 0 auto;
+
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 852px;
+  }
+  ${Devices.laptopM} {
+    width: 1140px;
+  }
+`;
+
+export const CTA = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 15px;
+  gap: 12px;
+  z-index: 9999;
+`;
+
+export const MenuList = styled.ul`
+  position: fixed;
+  top: 48;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0px 24px 0 24px;
+  gap: 16px;
+  z-index: 9999;
+`;
+
+export const MenuItem = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  line-height: 1.1428571429;
+  font-weight: 600;
+  letter-spacing: 0.007em;
+  text-decoration: none;
+`;
+
+export const MenuLink = styled(Link)`
+  font-size: 28px;
+  line-height: 1.1428571429;
+  font-weight: 600;
+  letter-spacing: 0.007em;
+  text-decoration: none;
+`;
+
+export const MenuButton = styled.div`
+  visibility: visible;
+  display: block;
+
+  ${Devices.tabletS} {
+    visibility: hidden;
+    display: none;
+
+    flex-direction: row;
+    align-items: center;
+  }
+`;
+
+export const handleBookAudit = (
+  event,
+  href,
+  instance = "navigation-sticky"
+) => {
+  if (event && event.preventDefault) {
+    event.preventDefault();
+  }
+  ReactGA.event({
+    category: "User",
+    action: "Clicked Book Audit",
+    label: `Book Audit - ${instance}`,
+    value: 10,
+    nonInteraction: false,
+  });
+  setTimeout(() => {
+    window.location.href = href;
+  }, 150);
+  console.log(`Clicked Book Audit - ${instance}`);
+};
+
+export const useNavigationMenu = () => {
+  const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    console.log("New page loaded:", location.pathname);
+    setMenuOpen(false);
+    return () => {
+      console.log("Component is unmounting");
+    };
+  }, [location.pathname]);
+
+  const openMenu = useCallback((event) => {
+    console.log("menuButtonClick 1");
+    if (event && event.preventDefault) {
+      event.preventDefault();
+    }
+    setMenuOpen(true);
+    console.log("menuButtonClick 2");
+  }, []);
+
+  const closeMenu = useCallback((event) => {
+    console.log("closeButtonClick 1");
+    if (event && event.preventDefault) {
+      event.preventDefault();
+    }
+    setMenuOpen(false);
+    console.log("closeButtonClick 2");
+  }, []);
+
+  return {
+    menuOpen,
+    currentPath: location.pathname,
+    openMenu,
+    closeMenu,
+  };
+};


### PR DESCRIPTION
## Summary
- extract shared navigation layout, menu helpers, and analytics into `Navigation/shared.js`
- refactor standard and sticky navigation variants to reuse shared primitives with variant-specific styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2bfa90c288327808c726fac325f71