### PR TITLE
Refactor layout primitives into shared components

### DIFF
--- a/src/components/Content/FlowCarousel/FlowCarousel.js
+++ b/src/components/Content/FlowCarousel/FlowCarousel.js
@@ -5,117 +5,113 @@ import { Devices, Colors } from "../../DesignSystem";
 
 import FlowItem from "./FlowItem";
 
+const FlowCarouselWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+  width: 100%;
+`;
+
+const CarouselScroller = styled.div`
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+`;
+
+const CarouselViewport = styled.div`
+  overflow: scroll hidden;
+  scrollbar-width: none;
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+`;
+
+const CarouselContent = styled.div`
+  min-width: 100%;
+`;
+
+const CarouselGrid = styled.div`
+  display: flex;
+  gap: 24px;
+  padding: 4px 20px 10px 20px;
+  width: min-content;
+
+  ${Devices.tabletS} {
+    padding: 4px 330px 10px 330px;
+  }
+`;
+
+const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0px;
+  margin: 0px auto 0px auto;
+  width: 90%;
+
+  ${Devices.tabletS} {
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 740px;
+  }
+`;
+
+const TitleLink = styled.a`
+  font-size: 20px;
+  line-height: 28px;
+  letter-spacing: 0;
+  font-weight: 500;
+  margin: 0;
+  color: ${Colors.primaryText.highEmphasis};
+  cursor: pointer;
+  text-decoration: none;
+`;
+
+const TitleAppendix = styled.span`
+  font-size: 20px;
+  line-height: 28px;
+  letter-spacing: 0;
+  font-weight: 500;
+  margin: 0;
+  color: ${Colors.primaryText.mediumEmphasis};
+  cursor: pointer;
+`;
+
+const CarouselSubline = styled.p`
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: 0.014em;
+  font-weight: 400;
+  margin: 0;
+  color: ${Colors.primaryText.mediumEmphasis};
+  cursor: pointer;
+`;
+
 const FlowCarousel = ({ data, appname, url }) => {
-  const FlowCarousel = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    position: relative;
-    width: 100%;
-
-    ${Devices.tabletS} {
-    }
-    ${Devices.tabletM} {
-    }
-    ${Devices.laptopS} {
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-  const Scroller = styled.div`
-    position: relative;
-    overflow: hidden;
-    width: 100%;
-  `;
-  const Carousel = styled.div`
-    overflow: scroll hidden;
-    scrollbar-width: none;
-    border-radius: inherit;
-    width: 100%;
-    height: 100%;
-  `;
-  const CarouselWrapper = styled.div`
-    min-width: 100%;
-  `;
-  const CarouselGrid = styled.div`
-    display: flex;
-    gap: 24px;
-    padding: 4px 20px 10px 20px;
-    width: min-content;
-    ${Devices.tabletS} {
-      padding: 4px 330px 10px 330px;
-    }
-    ${Devices.tabletM} {
-    }
-    ${Devices.laptopS} {
-    }
-  `;
-  const Text = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 0px;
-    margin: 0px auto 0px auto;
-    width: 90%;
-    ${Devices.tabletS} {
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-  const Titel = styled.a`
-    font-size: 20px;
-    line-height: 28px;
-    letter-spacing: 0;
-    font-weight: 500;
-    margin: 0;
-    color: ${Colors.primaryText.highEmphasis};
-    cursor: pointer;
-    text-decoration: none;
-  `;
-  const Appendix = styled.span`
-    font-size: 20px;
-    line-height: 28px;
-    letter-spacing: 0;
-    font-weight: 500;
-    margin: 0;
-    color: ${Colors.primaryText.mediumEmphasis};
-    cursor: pointer;
-  `;
-  const Subline = styled.p`
-    font-size: 14px;
-    line-height: 20px;
-    letter-spacing: 0.014em;
-    font-weight: 400;
-    margin: 0;
-    color: ${Colors.primaryText.mediumEmphasis};
-    cursor: pointer;
-  `;
-
   return (
-    <FlowCarousel>
-      <Scroller>
-        <Carousel>
-          <CarouselWrapper>
+    <FlowCarouselWrapper>
+      <CarouselScroller>
+        <CarouselViewport>
+          <CarouselContent>
             <CarouselGrid>
               {data.map((item) => (
                 <FlowItem key={item.id} {...item} image={item.image} />
               ))}
             </CarouselGrid>
-          </CarouselWrapper>
-        </Carousel>
-      </Scroller>
-      <Text>
-        <Titel href={url || "#"}>
-          {" "}
-          {appname} <Appendix>Onboarding & Activation Flow</Appendix>
-        </Titel>
-        <Subline>{data.length} Screens</Subline>
-      </Text>
-    </FlowCarousel>
+          </CarouselContent>
+        </CarouselViewport>
+      </CarouselScroller>
+      <TextWrapper>
+        <TitleLink href={url || "#"}>
+          {appname} <TitleAppendix>Onboarding & Activation Flow</TitleAppendix>
+        </TitleLink>
+        <CarouselSubline>{data.length} Screens</CarouselSubline>
+      </TextWrapper>
+    </FlowCarouselWrapper>
   );
 };
 

--- a/src/components/Content/FlowCarousel/FlowItem.js
+++ b/src/components/Content/FlowCarousel/FlowItem.js
@@ -3,91 +3,82 @@ import React from "react";
 
 import { Colors, Devices } from "../../DesignSystem";
 
+const FlowItemCard = styled.div`
+  border-radius: 12px;
+  width: 480px;
+  height: 100%;
+  margin: 0;
+  display: block;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-color: rgb(194, 194, 194);
+  border-width: 1px;
+  border-style: solid;
+`;
+
+const FlowItemWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 8 / 5;
+`;
+
+const FlowItemLink = styled.a`
+  display: flex;
+  position: absolute;
+  inset: 0px;
+  border-radius: 12px;
+
+  overflow: hidden;
+  cursor: zoom-in;
+
+  width: 100%;
+  height: 100%;
+
+  &:hover {
+    color: ${Colors.primaryText.highEmphasis};
+  }
+  &:visited {
+    color: ${Colors.primaryText.mediumEmphasis};
+    text-decoration: none;
+  }
+`;
+
+const FlowItemImage = styled.div`
+  flex-grow: 1;
+
+  ${Devices.tabletS} {
+  }
+  ${Devices.tabletM} {
+  }
+  ${Devices.laptopS} {
+  }
+  ${Devices.laptopM} {
+  }
+`;
+
+const FlowItemPicture = styled.img`
+  border-radius: 12px;
+  object-position: top;
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+`;
+
 const FlowItem = ({ image }) => {
-  const FlowItem = styled.div`
-    border-radius: 12px;
-    width: 480px;
-    height: 100%;
-    margin: 0;
-    display: block;
-    flex-shrink: 0;
-    overflow: hidden;
-    border-color: rgb(194, 194, 194);
-    border-width: 1px;
-    border-style: solid;
-
-    ${Devices.tabletS} {
-    }
-    ${Devices.tabletM} {
-    }
-    ${Devices.laptopS} {
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-
-  const Wrapper = styled.div`
-    position: relative;
-    width: 100%;
-    aspect-ratio: 8 / 5;
-  `;
-
-  const FlowItemLink = styled.a`
-    display: flex;
-    position: absolute;
-    inset: 0px;
-    border-radius: 12px;
-
-    overflow: hidden;
-    cursor: zoom-in;
-
-    width: 100%;
-    height: 100%;
-
-    &:hover {
-      color: ${Colors.primaryText.highEmphasis};
-    }
-    &:visited {
-      color: ${Colors.primaryText.mediumEmphasis};
-      text-decoration: none;
-    }
-  `;
-
-  const FlowItemImage = styled.div`
-    flex-grow: 1;
-
-    ${Devices.tabletS} {
-    }
-    ${Devices.tabletM} {
-    }
-    ${Devices.laptopS} {
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-
-  const Image = styled.img`
-    border-radius: 12px;
-    object-position: top;
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-  `;
-
   return (
-    <FlowItem>
-      <Wrapper>
+    <FlowItemCard>
+      <FlowItemWrapper>
         <FlowItemLink
           href={image || undefined}
           target={image ? "_blank" : undefined}
           rel={image ? "noopener noreferrer" : undefined}
         >
           <FlowItemImage>
-            <Image src={image} alt={""} />
+            <FlowItemPicture src={image} alt={""} />
           </FlowItemImage>
         </FlowItemLink>
-      </Wrapper>
-    </FlowItem>
+      </FlowItemWrapper>
+    </FlowItemCard>
   );
 };
 

--- a/src/components/Content/Section/SectionCopy.js
+++ b/src/components/Content/Section/SectionCopy.js
@@ -3,48 +3,48 @@ import styled from "@emotion/styled";
 
 import { Devices, Colors } from "../../DesignSystem";
 
-const SectionCopy = ({ copy }) => {
-  const SectionCopy = styled.p`
-    font-family: "Roboto", sans-serif;
-    font-style: normal;
-    font-weight: normal;
-    color: ${Colors.primaryText.highEmphasis};
-    margin: 0px 24px 24px 24px;
+const SectionCopyText = styled.p`
+  font-family: "Roboto", sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  color: ${Colors.primaryText.highEmphasis};
+  margin: 0px 24px 24px 24px;
 
-    font-size: 20px;
-    line-height: 120%;
+  font-size: 20px;
+  line-height: 120%;
+  text-align: left;
+
+  ${Devices.tabletS} {
     text-align: left;
+    width: 576px;
+  }
+  ${Devices.tabletM} {
+    width: 720px;
 
-    ${Devices.tabletS} {
-      text-align: left;
-      width: 576px;
-    }
-    ${Devices.tabletM} {
-      width: 720px;
+    font-size: 36px;
+    line-height: 111%;
+    margin-bottom: 32px;
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+  ${Devices.laptopS} {
+    width: 864px;
 
-      font-size: 36px;
-      line-height: 111%;
-      margin-bottom: 32px;
-      margin-left: 0px;
-      margin-right: 0px;
-    }
-    ${Devices.laptopS} {
-      width: 864px;
+    font-size: 36px;
+    line-height: 100%;
+    margin-bottom: 38px;
+  }
+  ${Devices.laptopM} {
+    width: 1152px;
 
-      font-size: 36px;
-      line-height: 100%;
-      margin-bottom: 38px;
-    }
-    ${Devices.laptopM} {
-      width: 1152px;
+    font-size: 42px;
+    line-height: 113%;
+    margin-bottom: 46px;
+  }
+`;
 
-      font-size: 42px;
-      line-height: 113%;
-      margin-bottom: 46px;
-    }
-  `;
-
-  return <SectionCopy>{copy}</SectionCopy>;
+const SectionCopy = ({ copy }) => {
+  return <SectionCopyText>{copy}</SectionCopyText>;
 };
 
 export default SectionCopy;

--- a/src/components/Content/Section/SectionHead.js
+++ b/src/components/Content/Section/SectionHead.js
@@ -8,52 +8,53 @@ import SectionSubline from "./SectionSubline";
 import SectionCopy from "./SectionCopy";
 import SectionDivider from "./SectionDivider";
 
-const SectionHead = ({ divider, headline, subline, copy }) => {
-  const SectionHead = styled.div`
-    /* Auto Layout */
-    display: flex;
-    flex-direction: column;
+const SectionHeadWrapper = styled.div`
+  /* Auto Layout */
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-content: flex-start;
+  padding: 0px;
+
+  position: static;
+
+  left: 0px;
+  top: 0px;
+
+  /* Inside Auto Layout */
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+  margin: 0px 24px 40px 24px;
+
+  ${Devices.tabletS} {
+    margin: 0px 0px 60px 0px;
+    width: 576px;
     align-items: flex-start;
     align-content: flex-start;
-    padding: 0px;
+  }
+  ${Devices.tabletM} {
+    width: 720px;
+    margin: 0px 0px 60px 0px;
+  }
+  ${Devices.laptopS} {
+    width: 864px;
+    margin: 0px 0px 60px 0px;
+  }
+  ${Devices.laptopM} {
+    width: 1152px;
+    margin: 0px 0px 60px 0px;
+  }
+`;
 
-    position: static;
-
-    left: 0px;
-    top: 0px;
-
-    /* Inside Auto Layout */
-    flex: none;
-    order: 0;
-    flex-grow: 0;
-    margin: 0px 24px 40px 24px;
-
-    ${Devices.tabletS} {
-      margin: 0px 0px 60px 0px;
-      width: 576px;
-      align-items: flex-start;
-      align-content: flex-start;
-    }
-    ${Devices.tabletM} {
-      width: 720px;
-      margin: 0px 0px 60px 0px;
-    }
-    ${Devices.laptopS} {
-      width: 864px;
-      margin: 0px 0px 60px 0px;
-    }
-    ${Devices.laptopM} {
-      width: 1152px;
-      margin: 0px 0px 60px 0px;
-    }
-  `;
+const SectionHead = ({ divider, headline, subline, copy }) => {
   return (
-    <SectionHead>
+    <SectionHeadWrapper>
       {divider && <SectionDivider text={divider} />}
       {headline && <SectionHeadline headline={headline} />}
       {subline && <SectionSubline subline={subline} />}
       {copy && <SectionCopy copy={copy} />}
-    </SectionHead>
+    </SectionHeadWrapper>
   );
 };
 

--- a/src/components/Layout/Chips.js
+++ b/src/components/Layout/Chips.js
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+
+import { Colors, Devices } from "../DesignSystem";
+
+export const ChipRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 12px;
+  width: 90%;
+
+  ${Devices.tabletS} {
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 740px;
+  }
+`;
+
+export const ChipPill = styled.div`
+  font-family: "Roboto", sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  color: ${Colors.primaryText.highEmphasis};
+  background-color: white;
+  border-radius: 20px;
+  padding: 8px 16px 8px 16px;
+  cursor: default;
+  white-space: nowrap;
+`;

--- a/src/components/Layout/Grids.js
+++ b/src/components/Layout/Grids.js
@@ -1,0 +1,97 @@
+import styled from "@emotion/styled";
+
+import { Devices } from "../DesignSystem";
+
+export const CaseCardGrid = styled.section`
+  margin: 0px;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: center;
+  align-items: center;
+  gap: 24px;
+  margin-bottom: calc(-1 * var(--gap));
+
+  & > * {
+    margin-left: var(--gap);
+    margin-bottom: var(--gap);
+  }
+
+  ${Devices.tabletS} {
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+  }
+  ${Devices.laptopS} {
+    width: 852px;
+  }
+  ${Devices.laptopM} {
+    width: 1140px;
+  }
+`;
+
+export const PricePanelGrid = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 12px;
+  justify-content: center;
+  align-content: center;
+  align-items: stretch;
+  --gap: 12px;
+
+  margin-bottom: calc(1 * var(--gap));
+  margin-right: 12px;
+  margin-left: 12px;
+
+  ${Devices.tabletS} {
+    width: 576px;
+    margin-right: 0px;
+    margin-left: 0px;
+    margin-bottom: calc(-1 * var(--gap));
+  }
+  ${Devices.tabletM} {
+    width: 720px;
+    flex-direction: row;
+  }
+  ${Devices.laptopS} {
+    width: 864px;
+  }
+  ${Devices.laptopM} {
+    width: 1152px;
+  }
+`;
+
+export const DeliverablesGrid = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: center;
+  align-items: flex-start;
+  column-gap: 16px;
+  row-gap: 16px;
+  margin-left: 12px;
+  margin-right: 12px;
+
+  ${Devices.tabletS} {
+    margin-left: 0px;
+    margin-right: 0px;
+    width: 576px;
+  }
+  ${Devices.tabletM} {
+    width: 720px;
+    flex-direction: row;
+  }
+  ${Devices.laptopS} {
+    width: 864px;
+  }
+  ${Devices.laptopM} {
+    width: 1152px;
+  }
+`;

--- a/src/components/Layout/Page.js
+++ b/src/components/Layout/Page.js
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+
+import { Devices } from "../DesignSystem";
+
+export const PageContent = styled.div`
+  text-align: left;
+  margin-top: 72px;
+`;
+
+export const PageSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  align-self: stretch;
+  flex-grow: 0;
+`;
+
+export const PaddedPageSection = styled(PageSection)`
+  flex: none;
+  order: 3;
+  align-items: stretch;
+  margin-bottom: 200px;
+
+  ${Devices.tabletS} {
+    align-items: center;
+  }
+`;
+
+export const PageHeaderSection = styled(PaddedPageSection)`
+  margin-bottom: 40px;
+
+  ${Devices.tabletS} {
+    margin-bottom: 200px;
+  }
+`;
+
+export const PageParagraph = styled(PageSection)`
+  margin-bottom: 140px;
+`;

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -1,0 +1,3 @@
+export * from "./Page";
+export * from "./Grids";
+export * from "./Chips";

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -8,6 +8,141 @@ import Identity from "../Identity/Identity";
 import LandingpageMenu from "./LandingpageMenu";
 import { X, Menu } from "lucide-react";
 import Button from "../Button/Button";
+
+const NavigationWrapper = styled.header`
+  margin: 0 auto;
+  height: 220px;
+  width: 100%;
+  z-index: 1000;
+`;
+
+const NavigationContainer = styled.header`
+  height: 132px;
+  padding-bottom: 72px;
+  border-bottom: 1px solid;
+  border-color: ${Colors.primaryText.highEmphasis};
+  margin-right: 24px;
+  margin-left: 24px;
+
+  ${Devices.tabletS} {
+    margin: 0 auto;
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 852px;
+  }
+  ${Devices.laptopM} {
+    width: 1140px;
+  }
+`;
+
+const GlobalNavCurtain = styled.div`
+  background: rgba(232, 232, 237, 0.4);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  visibility: hidden;
+  position: fixed;
+  opacity: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 9998;
+  transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
+    visibility 0.32s step-end 80ms;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  background: rgba(255, 255, 255, 0.7);
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
+    visibility 0.32s step-start 80ms;
+  backdrop-filter: blur(20px);
+`;
+
+const NavigationMenuMobile = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  height: 52px;
+  z-index: 9999;
+  margin-right: 24px;
+  margin-left: 24px;
+
+  ${Devices.tabletS} {
+    margin: 0 auto;
+    width: 564px;
+  }
+  ${Devices.tabletM} {
+    width: 708px;
+  }
+  ${Devices.laptopS} {
+    width: 852px;
+  }
+  ${Devices.laptopM} {
+    width: 1140px;
+  }
+`;
+
+const CallToAction = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 15px;
+  gap: 12px;
+  z-index: 9999;
+`;
+
+const MenuList = styled.ul`
+  position: fixed;
+  top: 48;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 0px 24px 0 24px;
+  gap: 16px;
+  z-index: 9999;
+`;
+
+const MenuItem = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  line-height: 1.1428571429;
+  font-weight: 600;
+  letter-spacing: 0.007em;
+  text-decoration: none;
+`;
+
+const MenuLinkStyled = styled(Link)`
+  font-size: 28px;
+  line-height: 1.1428571429;
+  font-weight: 600;
+  letter-spacing: 0.007em;
+  text-decoration: none;
+`;
+
+const MenuButtonWrapper = styled.div`
+  visibility: visible;
+  display: block;
+
+  ${Devices.tabletS} {
+    visibility: hidden;
+    display: none;
+    flex-direction: row;
+    align-items: center;
+  }
+`;
 const Navigation = (props) => {
   const location = useLocation();
   const currentPath = location.pathname;
@@ -29,154 +164,6 @@ const Navigation = (props) => {
     setMenuOpen(false);
   };
 
-  const NavigationWrapper = styled.header`
-   
-    margin: 0 auto;
-    height: 220px;
-    width: 100%;
-    
-   
-  
-    z-index: 1000;
-    ${Devices.tabletS} {
-     
-    }
-    ${Devices.tabletM} {
-     
-    }
-    ${Devices.laptopS} {
- 
-    }
-    ${Devices.laptopM} {
-      
-  `;
-  const Navigation = styled.header`
-    height: 132px;
-    padding-bottom: 72px;
-    border-bottom: 1px solid;
-    border-color: ${Colors.primaryText.highEmphasis};
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const GlobalNavCurtain = styled.div`
-    background: rgba(232, 232, 237, 0.4);
-    -webkit-backdrop-filter: blur(20px);
-    backdrop-filter: blur(20px);
-    visibility: hidden;
-    position: fixed;
-    opacity: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 9998;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-end 80ms;
-    -webkit-backdrop-filter: none;
-    backdrop-filter: none;
-    background: rgba(255, 255, 255, 0.7);
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.32s cubic-bezier(0.4, 0, 0.6, 1) 80ms,
-      visibility 0.32s step-start 80ms;
-    backdrop-filter: blur(20px);
-  `;
-
-  const NavigationMenuMobile = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    height: 52px;
-    z-index: 9999;
-
-    margin-right: 24px;
-    margin-left: 24px;
-    ${Devices.tabletS} {
-      margin: 0 auto;
-
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-    }
-    ${Devices.laptopM} {
-      width: 1140px;
-    }
-  `;
-
-  const CTA = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    padding-top: 15px;
-    gap: 12px;
-    z-index: 9999;
-  `;
-
-  const MenuList = styled.ul`
-    position: fixed;
-    top: 48;
-    left: 0;
-    right: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 0px 24px 0 24px;
-    gap: 16px;
-    z-index: 9999;
-  `;
-
-  const MenuItem = styled.li`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-  const MenuLink = styled(Link)`
-    font-size: 28px;
-    line-height: 1.1428571429;
-    font-weight: 600;
-    letter-spacing: 0.007em;
-    text-decoration: none;
-  `;
-
-  const MenuButton = styled.div`
-    visibility: visible;
-    display: block;
-
-    ${Devices.tabletS} {
-      visibility: hidden;
-      display: none;
-
-      flex-direction: row;
-      align-items: center;
-    }
-  `;
   const hanldeBookAudit = (e, href, instance = "navigation-sticky") => {
     e.preventDefault();
     ReactGA.event({
@@ -194,15 +181,15 @@ const Navigation = (props) => {
     <NavigationWrapper>
       {menuOpen ? (
         <NavigationMenuMobile>
-          <CTA>
-            <MenuButton onClick={closeButtonClick}>
+          <CallToAction>
+            <MenuButtonWrapper onClick={closeButtonClick}>
               {" "}
               <X size={24} strokeWidth={1} />
-            </MenuButton>
-          </CTA>
+            </MenuButtonWrapper>
+          </CallToAction>
           <MenuList>
             <MenuItem>
-              <MenuLink
+              <MenuLinkStyled
                 to="/case-studies"
                 style={{
                   color:
@@ -213,10 +200,10 @@ const Navigation = (props) => {
                 }}
               >
                 Case Studies
-              </MenuLink>
+              </MenuLinkStyled>
             </MenuItem>
             <MenuItem>
-              <MenuLink
+              <MenuLinkStyled
                 to="/reports"
                 style={{
                   color:
@@ -227,10 +214,10 @@ const Navigation = (props) => {
                 }}
               >
                 Reports
-              </MenuLink>
+              </MenuLinkStyled>
             </MenuItem>
             <MenuItem>
-              <MenuLink
+              <MenuLinkStyled
                 to="/flows"
                 style={{
                   color:
@@ -241,15 +228,15 @@ const Navigation = (props) => {
                 }}
               >
                 Flow Gallery
-              </MenuLink>
+              </MenuLinkStyled>
             </MenuItem>
           </MenuList>
         </NavigationMenuMobile>
       ) : (
-        <Navigation>
+        <NavigationContainer>
           <Identity />
 
-          <CTA>
+          <CallToAction>
             <LandingpageMenu />
 
             <Button
@@ -265,11 +252,11 @@ const Navigation = (props) => {
               text={"Book intro call"}
               gradient={{ from: Colors.blue, to: Colors.blueDark }}
             />
-            <MenuButton onClick={menuButtonClick}>
+            <MenuButtonWrapper onClick={menuButtonClick}>
               <Menu size={24} strokeWidth={1} />
-            </MenuButton>
-          </CTA>
-        </Navigation>
+            </MenuButtonWrapper>
+          </CallToAction>
+        </NavigationContainer>
       )}
       {menuOpen && <GlobalNavCurtain />}
     </NavigationWrapper>

--- a/src/components/Pages/Flows/FlowPageTemplate.js
+++ b/src/components/Pages/Flows/FlowPageTemplate.js
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { motion, useAnimation } from "framer-motion";
 import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
@@ -7,7 +6,14 @@ import { useInView } from "react-intersection-observer";
 import { getFlowMeta } from "../../../data/flows";
 
 // DESIGN SYSTEM
-import { Colors, Devices } from "../../DesignSystem";
+import {
+  CaseCardGrid,
+  ChipPill,
+  ChipRow,
+  PageContent,
+  PageParagraph,
+  PageSection,
+} from "../../Layout";
 
 //COMPONENTS
 import CaseSectionHead from "../../Content/Case/CaseSectionHead";
@@ -51,101 +57,13 @@ function FadeInWhenVisible({ children }) {
   );
 }
 
-const ContentWrapper = styled.div`
-  text-align: left;
-  margin-top: 72px;
-`;
-
-const Section = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  align-self: stretch;
-  flex-grow: 0;
-`;
-
-const Paragraph = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  align-self: stretch;
-  flex-grow: 0;
-  margin-bottom: 140px;
-`;
-
-const CaseCardGrid = styled.section`
-  margin: 0px;
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-content: center;
-  align-items: center;
-  gap: 24px;
-  margin-bottom: calc(-1 * var(--gap));
-
-  & > * {
-    margin-left: var(--gap);
-    margin-bottom: var(--gap);
-  }
-
-  ${Devices.tabletS} {
-    width: 564px;
-  }
-  ${Devices.tabletM} {
-    width: 708px;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-  }
-  ${Devices.laptopS} {
-    width: 852px;
-  }
-  ${Devices.laptopM} {
-    width: 1140px;
-  }
-`;
-
-const Chips = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 12px;
-  width: 90%;
-
-  ${Devices.tabletS} {
-    width: 564px;
-  }
-  ${Devices.tabletM} {
-    width: 708px;
-  }
-  ${Devices.laptopS} {
-    width: 740px;
-  }
-`;
-
-const Chip = styled.div`
-  font-family: "Roboto", sans-serif;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
-  color: ${Colors.primaryText.highEmphasis};
-  background-color: white;
-  border-radius: 20px;
-  padding: 8px 16px 8px 16px;
-  cursor: default;
-  white-space: nowrap;
-`;
-
 const RelatedResourcesWrapper = ({ resources }) => {
   if (!resources || resources.length === 0) {
     return null;
   }
 
   return (
-    <Paragraph>
+    <PageParagraph>
       <CaseSectionHead headline={"Related Ressources"} />
       <CaseCardGrid>
         {resources.map((resource) => (
@@ -154,7 +72,7 @@ const RelatedResourcesWrapper = ({ resources }) => {
           </FadeInWhenVisible>
         ))}
       </CaseCardGrid>
-    </Paragraph>
+    </PageParagraph>
   );
 };
 
@@ -177,23 +95,23 @@ const FlowPageTemplate = ({ flowSlug, screens = [], relatedResources }) => {
     "Explore detailed onboarding and activation flows from leading products.";
 
   return (
-    <ContentWrapper>
+    <PageContent>
       <Helmet>
         <meta charSet="utf-8" />
         <title>{pageTitle}</title>
         <meta name="description" content={pageDescription} />
       </Helmet>
-      <Section>
+      <PageSection>
         <CaseTitleEyebrow text={"Flow"} color1="#00b8d4" color2="#62ebff" />
         <CaseTitle headline={flowMeta.name} />
         <CaseSubline subline={flowMeta.desc} />
 
         {chips.length > 0 && (
-          <Chips>
+          <ChipRow>
             {chips.map((chipValue) => (
-              <Chip key={chipValue}>{chipValue}</Chip>
+              <ChipPill key={chipValue}>{chipValue}</ChipPill>
             ))}
-          </Chips>
+          </ChipRow>
         )}
         <br />
         <br />
@@ -204,8 +122,8 @@ const FlowPageTemplate = ({ flowSlug, screens = [], relatedResources }) => {
         <br />
         <br />
         <RelatedResourcesWrapper resources={relatedResources} />
-      </Section>
-    </ContentWrapper>
+      </PageSection>
+    </PageContent>
   );
 };
 

--- a/src/components/Pages/Home/Home.js
+++ b/src/components/Pages/Home/Home.js
@@ -24,6 +24,13 @@ import { Check, X } from "lucide-react";
 import AccordeonVisual from "../../Content/AccordeonVisual/AccordeonVisual";
 import PricingCanvas from "../../Content/PricingCanvas/PricingCanvas";
 import Lightbox from "../../Lightbox/Lightbox";
+import {
+  DeliverablesGrid,
+  PageContent,
+  PageHeaderSection,
+  PaddedPageSection,
+  PricePanelGrid,
+} from "../../Layout";
 
 const ROICalculatorTitle = styled.h3`
   margin: 0 0 8px 0;
@@ -239,108 +246,6 @@ function MoveUpWhenVisible({ children }) {
     </motion.div>
   );
 }
-
-const ContentWrapper = styled.div`
-  text-align: left;
-  margin-top: 72px;
-`;
-
-const Section = styled.section`
-  /* Auto Layout */
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-
-  /* Inside Auto Layout */
-  flex: none;
-  order: 3;
-  align-self: stretch;
-  align-items: stretch;
-  flex-grow: 0;
-  margin-bottom: 200px;
-  ${Devices.tabletS} {
-    align-items: center;
-  }
-`;
-const HeaderSection = styled.section`
-  /* Auto Layout */
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-
-  /* Inside Auto Layout */
-  flex: none;
-  order: 3;
-  align-self: stretch;
-  align-items: stretch;
-  flex-grow: 0;
-  margin-bottom: 40px;
-  ${Devices.tabletS} {
-    align-items: center;
-    margin-bottom: 200px;
-  }
-`;
-const PricePanels = styled.section`
-  display: flex;
-  flex-direction: column;
-  flex-wrap: nowrap;
-  gap: 12px;
-  justify-content: center;
-  align-content: center;
-  align-items: stretch;
-  --gap: 12px;
-
-  margin-bottom: calc(1 * var(--gap));
-  margin-right: 12px;
-  margin-left: 12px;
-
-  ${Devices.tabletS} {
-    width: 576px;
-    margin-right: 0px;
-    margin-left: 0px;
-    margin-bottom: calc(-1 * var(--gap));
-  }
-  ${Devices.tabletM} {
-    width: 720px;
-    flex-direction: row;
-  }
-  ${Devices.laptopS} {
-    width: 864px;
-  }
-  ${Devices.laptopM} {
-    width: 1152px;
-  }
-`;
-const DeliverablesCards = styled.section`
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-content: center;
-  align-items: flex-start;
-  column-gap: 16px;
-  row-gap: 16px;
-  margin-left: 12px;
-  margin-right: 12px;
-
-  ${Devices.tabletS} {
-    margin-left: 0px;
-    margin-right: 0px;
-    width: 576px;
-  }
-  ${Devices.tabletM} {
-    width: 720px;
-    flex-direction: row;
-  }
-  ${Devices.laptopS} {
-    width: 864px;
-  }
-  ${Devices.laptopM} {
-    width: 1152px;
-  }
-`;
 
 const Hero = styled.div`
   /* Auto Layout */
@@ -1603,8 +1508,8 @@ const Content = (props) => {
   const roiResults = calculateROI();
 
   return (
-    <ContentWrapper>
-      <HeaderSection>
+    <PageContent>
+      <PageHeaderSection>
         <Hero>
           <HeroHeadline>
             Let's fix your leaky onboarding.
@@ -1667,14 +1572,14 @@ const Content = (props) => {
             </LightboxOverlay>
           )}
         </Hero>
-      </HeaderSection>
-      <Section>
+      </PageHeaderSection>
+      <PaddedPageSection>
         <PricingCanvas
           roiCalcAction={(e) => handleClickROICalculator(e, "pricing-canvas")}
         />
-      </Section>
+      </PaddedPageSection>
 
-      <Section>
+      <PaddedPageSection>
         <ProblemHeadline>
           <span style={{ color: "black" }}>The Problem</span>
           <br />
@@ -1805,11 +1710,11 @@ const Content = (props) => {
             />
           </ModalActions>
         </Lightbox>
-      </Section>
-      <Section>
+      </PaddedPageSection>
+      <PaddedPageSection>
         <BusinessCard />
-      </Section>
-      <Section>
+      </PaddedPageSection>
+      <PaddedPageSection>
         <SolutionHeadline>
           <span style={{ color: "black" }}>Our Solution</span>
           <br />A 2–week sprint to fine-tune your product’s onboarding
@@ -2086,12 +1991,12 @@ const Content = (props) => {
           </ModalActions>
         </Lightbox>
 
-      </Section>
+      </PaddedPageSection>
 
-      <Section>
+      <PaddedPageSection>
         <DeliverablesHeadline>Your Deliverables</DeliverablesHeadline>
 
-        <DeliverablesCards>
+        <DeliverablesGrid>
           <DeliverablesCard
             headline="Positioning"
             img="../img/Landingpage/Deliverables/Positioning.png"
@@ -2122,16 +2027,16 @@ const Content = (props) => {
             color2={Colors.blueDark}
             copy="A prioritized list of improvements and experiments for you to get started and plan implementation right away."
           />
-        </DeliverablesCards>
-      </Section>
-      <Section>
+        </DeliverablesGrid>
+      </PaddedPageSection>
+      <PaddedPageSection>
         <SolutionSubline>How it works</SolutionSubline>
 
         <AccordeonVisual />
-      </Section>
-      <Section>
+      </PaddedPageSection>
+      <PaddedPageSection>
         <Headline2 headline="Onboarding Development Sprint" />
-        <PricePanels>
+        <PricePanelGrid>
           <PricePanel>
             <PanelContent>
               <PricePanelTitle>
@@ -2364,7 +2269,7 @@ const Content = (props) => {
               />
             </PanelContent>
           </PricePanel>
-        </PricePanels>
+        </PricePanelGrid>
 
         <div
           style={{ display: "flex", justifyContent: "center", marginTop: 32 }}
@@ -2377,9 +2282,9 @@ const Content = (props) => {
             color="#000000"
           />
         </div>
-      </Section>
+      </PaddedPageSection>
 
-      <Section>
+      <PaddedPageSection>
         <Headline2 headline="Questions? Answers." />
 
         <MoveUpWhenVisible>
@@ -2418,8 +2323,8 @@ Wireframe mockups with detailed recommendations for updating your onboarding scr
             copy="Yes, I offer a retainer service to continuously refine, test and optimize your onboarding flow and other user journeys based on real user data and feedback. I also advise in other areas of product-led growth."
           />
         </MoveUpWhenVisible>
-      </Section>
-      <Section>
+      </PaddedPageSection>
+      <PaddedPageSection>
         <Hero>
           <HeroHeadline>
             Let's fix your <OnboardingGradient>onboarding</OnboardingGradient>{" "}
@@ -2449,8 +2354,8 @@ Wireframe mockups with detailed recommendations for updating your onboarding scr
             gradient={{ from: Colors.blue, to: Colors.blueDark }}
           />
         </Hero>
-      </Section>
-    </ContentWrapper>
+      </PaddedPageSection>
+    </PageContent>
   );
 };
 


### PR DESCRIPTION
## Summary
- create shared layout primitives for page wrappers, grids, and chip rows in a new layout module
- update home and flow pages to consume shared layout components and avoid styled-component shadowing
- hoist navigation, flow carousel, and section styled elements to module scope for reuse

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d39d46c24083278f61f6f6936b8bc5