### PR TITLE
Add CTA and lead gen form tests with CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,78 +1,27 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - "**"
   pull_request:
-    branches: [master, staging]
-
-permissions:
-  contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: "npm"
-      - run: npm ci
-      - name: Build
-        run: |
-          if npm run | grep -q " build"; then
-            npm run build
-          else
-            echo "No build script found. Skipping."
-          fi
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: "npm"
-      - run: npm ci
-      - name: Lint
-        run: |
-          if npm run | grep -q " lint"; then
-            npm run lint
-          else
-            echo "No lint script found. Skipping."
-          fi
-
   test:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: "npm"
-      - run: npm ci
-      - name: Test
-        env: { CI: true }
-        run: |
-          if npm run | grep -q " test"; then
-            npm test -- --watch=false || npm test -- --watchAll=false
-          else
-            echo "No test script found. Skipping."
-          fi
 
-  typecheck:
-    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: "npm"
-      - run: npm ci
-      - name: TypeScript type check
-        run: |
-          if [ -f tsconfig.json ]; then
-            npx tsc --noEmit
-          else
-            echo "No tsconfig.json; skipping."
-          fi
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --watchAll=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,26 +2,93 @@ name: CI
 
 on:
   push:
-    branches:
-      - "**"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: npm
+          cache: "npm"
+      - run: npm ci
+      - name: Build
+        run: |
+          if npm run | grep -q " build"; then
+            npm run build
+          else
+            echo "No build script found. Skipping."
+          fi
 
-      - name: Install dependencies
-        run: npm ci
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+      - run: npm ci
+      - name: Lint
+        run: |
+          if npm run | grep -q " lint"; then
+            npm run lint
+          else
+            echo "No lint script found. Skipping."
+          fi
 
-      - name: Run tests
-        run: npm test -- --watchAll=false
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+      - run: npm ci
+      - name: Test
+        env:
+          CI: true
+        run: |
+          if npm run | grep -q " test"; then
+            npm test -- --watch=false || npm test -- --watchAll=false
+          else
+            echo "No test script found. Skipping."
+          fi
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+      - run: npm ci
+      - name: TypeScript type check
+        run: |
+          if [ -f tsconfig.json ]; then
+            npx tsc --noEmit
+          else
+            echo "No tsconfig.json; skipping."
+          fi
+
+  targeted-tests:
+    name: CTA and lead gen tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+      - run: npm ci
+      - name: Run CTA and lead gen tests
+        env:
+          CI: true
+        run: npm test -- --watchAll=false --testPathPattern='home\.cta\.test\.jsx|LeadGenerationForm\.test\.jsx'

--- a/src/components/LeadGen/__tests__/LeadGenerationForm.test.jsx
+++ b/src/components/LeadGen/__tests__/LeadGenerationForm.test.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import LeadGenerationForm from "../LeadGenerationForm";
+
+describe("LeadGenerationForm", () => {
+  const originalFetch = global.fetch;
+  const mockSuccessLink = "https://example.com/report.pdf";
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+      })
+    );
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { href: "https://example.com/report" },
+    });
+    document.title = "Test Report";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    jest.clearAllMocks();
+  });
+
+  it("submits the form to HubSpot and shows the success state", async () => {
+    render(
+      <LeadGenerationForm
+        portal="12345"
+        form="abcde-12345"
+        successLink={mockSuccessLink}
+      />
+    );
+
+    const nameInput = screen.getByPlaceholderText(/First Name\*/i);
+    fireEvent.change(nameInput, { target: { value: "Jane" } });
+    fireEvent.blur(nameInput, { target: { value: "Jane" } });
+
+    const emailInput = screen.getByPlaceholderText(/Email\*/i);
+    fireEvent.change(emailInput, { target: { value: "jane@example.com" } });
+    fireEvent.blur(emailInput, { target: { value: "jane@example.com" } });
+
+    const submitButton = screen.getByText(/Submit/i);
+    fireEvent.click(submitButton);
+
+    const successHeading = await screen.findByText(/Success!/i);
+    expect(successHeading).toBeInTheDocument();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.hsforms.com/submissions/v3/integration/submit/12345/abcde-12345",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const fetchCall = global.fetch.mock.calls[0][1];
+    const payload = JSON.parse(fetchCall.body);
+    expect(payload.fields).toEqual([
+      { name: "firstname", value: "Jane" },
+      { name: "email", value: "jane@example.com" },
+    ]);
+    expect(payload.context).toEqual({
+      pageUri: "https://example.com/report",
+      pageName: "Test Report",
+    });
+
+    expect(
+      screen.getByText(/Check your inbox for the document/i)
+    ).toBeInTheDocument();
+
+    const downloadLink = screen.getByText(/Begin Download/i);
+    expect(downloadLink.closest("a")).toHaveAttribute("href", mockSuccessLink);
+  });
+});

--- a/src/components/Pages/Home/__tests__/home.cta.test.jsx
+++ b/src/components/Pages/Home/__tests__/home.cta.test.jsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+import Content from "../Home";
+import ReactGA from "react-ga4";
+
+jest.mock("react-ga4", () => ({
+  event: jest.fn(),
+}));
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children }) => <div>{children}</div>,
+  },
+  useAnimation: () => ({
+    start: jest.fn(),
+  }),
+}));
+
+jest.mock("react-intersection-observer", () => ({
+  useInView: () => {
+    const ref = jest.fn();
+    return [ref, true];
+  },
+}));
+
+describe("Home page CTAs", () => {
+  let originalOpen;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    ReactGA.event.mockClear();
+    originalOpen = window.open;
+    window.open = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    window.open = originalOpen;
+  });
+
+  it("tracks analytics and opens the booking link for 'Book intro call'", () => {
+    render(<Content />);
+
+    const bookButtons = screen.getAllByText(/Book intro call/i);
+    const heroButton = bookButtons[0];
+
+    fireEvent.click(heroButton);
+
+    expect(ReactGA.event).toHaveBeenCalledWith({
+      category: "User",
+      action: "book_audit_click",
+      label: "Book Audit - hero-section",
+      value: 10,
+      nonInteraction: false,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(window.open).toHaveBeenCalledWith(
+      "https://calendar.notion.so/meet/alexandros/onboarding-discovery",
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("opens the Loom demo and records analytics when 'Watch a Demo' is clicked", () => {
+    render(<Content />);
+
+    const watchDemoButton = screen.getByText(/Watch a Demo/i);
+    fireEvent.click(watchDemoButton);
+
+    expect(ReactGA.event).toHaveBeenCalledWith({
+      category: "User",
+      action: "watch_demo_clicked",
+      label: "Watch Demo",
+      value: 10,
+      nonInteraction: false,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(screen.getByTitle(/Loom video/i)).toBeInTheDocument();
+  });
+
+  it("reveals the ROI calculator lightbox with analytics tracking", () => {
+    render(<Content />);
+
+    const roiButton = screen
+      .getAllByText(/Calculate Onboarding ROI/i)
+      .find((element) => element.tagName.toLowerCase() === "a");
+
+    fireEvent.click(roiButton);
+
+    expect(ReactGA.event).toHaveBeenCalledWith({
+      category: "User",
+      action: "roi_calculator_click",
+      label: "ROI Calculator - pricing-canvas",
+      value: 10,
+      nonInteraction: false,
+    });
+
+    expect(screen.getAllByText(/Calculate Onboarding ROI/i).length).toBeGreaterThan(1);
+  });
+
+  it("opens the self-check modal and triggers analytics", () => {
+    render(<Content />);
+
+    const selfCheckButton = screen.getByText(/Take Onboarding Self-Check/i);
+    fireEvent.click(selfCheckButton);
+
+    expect(ReactGA.event).toHaveBeenCalledWith({
+      category: "User",
+      action: "self_check_click",
+      label: "Self Check",
+      value: 10,
+      nonInteraction: false,
+    });
+
+    expect(screen.getAllByText(/Onboarding Self-Check/i).length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests covering CTA analytics, navigation, and modal behavior on the home page
- add Jest test for HubSpot lead generation form submission success path
- configure GitHub Actions workflow to run the Jest suite on pushes and pull requests

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d3a9b74c8083278ffa07dfe53aaa1e