### PR TITLE
Refactor in-view animations into reusable helper

### DIFF
--- a/src/components/Content/FlipCard/FlipCard.js
+++ b/src/components/Content/FlipCard/FlipCard.js
@@ -1,7 +1,5 @@
-import React, { useEffect } from "react";
+import React from "react";
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import { useInView } from "react-intersection-observer";
 
 import { Devices, Colors } from "../../DesignSystem";
 
@@ -10,6 +8,7 @@ import FlipCardCopy from "./FlipCardCopy";
 import { mdiPlus } from "@mdi/js";
 import Icon from "@mdi/react";
 import { useState } from "react";
+import InViewMotion from "../../animation/InViewMotion";
 
 const FlipCard = ({
   eyebrow,
@@ -126,39 +125,6 @@ const FlipCard = ({
     }
   `;
 
-  function FadeInWhenVisible({ children }) {
-    const controls = useAnimation();
-    const [ref, inView] = useInView();
-
-    useEffect(() => {
-      if (inView) {
-        controls.start("visible");
-      }
-    }, [controls, inView]);
-
-    return (
-      <motion.div
-        ref={ref}
-        animate={controls}
-        initial="hidden"
-        transition={{ duration: 0.3 }}
-        variants={{
-          visible: {
-            opacity: 1,
-            transition: {
-              staggerChildren: 0.3,
-            },
-          },
-          hidden: {
-            opacity: 0,
-          },
-        }}
-      >
-        {children}
-      </motion.div>
-    );
-  }
-
   const flipCard = (e) => {
     e.preventDefault();
     setIsFlipped(!isFlipped);
@@ -188,9 +154,9 @@ const FlipCard = ({
         )}
         <br />
         {copy && (
-          <FadeInWhenVisible>
+          <InViewMotion>
             <FlipCardCopy textArray={copyBack} />{" "}
-          </FadeInWhenVisible>
+          </InViewMotion>
         )}
         {/*jpg && <FlipCardImage jpg={jpg} png={png} webp={webp} />*/}
       </BackContent>

--- a/src/components/Content/Landingpage/Head.js
+++ b/src/components/Content/Landingpage/Head.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import styled from "@emotion/styled";
 
 import { Colors, Devices } from "../../DesignSystem";
@@ -8,39 +8,7 @@ import HeadSubline from "./HeadSubline";
 import HeadDivider from "./HeadDivider";
 
 import Button from "../../Button/Button";
-
-import { useInView } from "react-intersection-observer";
-import { motion, useAnimation } from "framer-motion";
-
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+import InViewMotion from "../../animation/InViewMotion";
 
 const Head = ({ divider, headline, subline, cta }) => {
   const Head = styled.div`
@@ -82,7 +50,7 @@ const Head = ({ divider, headline, subline, cta }) => {
     }
   `;
   return (
-    <FadeInWhenVisible>
+    <InViewMotion staggerChildren={null}>
       <Head>
         {divider && <HeadDivider text={divider} />}
         {headline && <HeadHeadline headline={headline} />}
@@ -97,7 +65,7 @@ const Head = ({ divider, headline, subline, cta }) => {
           />
         )}
       </Head>
-    </FadeInWhenVisible>
+    </InViewMotion>
   );
 };
 

--- a/src/components/Pages/Flows/FlowPageTemplate.js
+++ b/src/components/Pages/Flows/FlowPageTemplate.js
@@ -1,7 +1,5 @@
-import { motion, useAnimation } from "framer-motion";
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
-import { useInView } from "react-intersection-observer";
 
 import { getFlowMeta } from "../../../data/flows";
 
@@ -23,39 +21,7 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 import CaseCard from "../../Content/CaseCard/CaseCard";
 
 import FlowCarousel from "../../Content/FlowCarousel/FlowCarousel";
-
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+import InViewMotion from "../../animation/InViewMotion";
 
 const RelatedResourcesWrapper = ({ resources }) => {
   if (!resources || resources.length === 0) {
@@ -67,9 +33,9 @@ const RelatedResourcesWrapper = ({ resources }) => {
       <CaseSectionHead headline={"Related Ressources"} />
       <CaseCardGrid>
         {resources.map((resource) => (
-          <FadeInWhenVisible key={resource.headline}>
+          <InViewMotion key={resource.headline}>
             <CaseCard {...resource} />
-          </FadeInWhenVisible>
+          </InViewMotion>
         ))}
       </CaseCardGrid>
     </PageParagraph>

--- a/src/components/Pages/Heraklit/Heraklit.js
+++ b/src/components/Pages/Heraklit/Heraklit.js
@@ -1,8 +1,6 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import { useInView } from "react-intersection-observer";
 
 //Components
 import { Devices } from "../../DesignSystem";
@@ -11,38 +9,7 @@ import CaseSectionHead from "../../Content/Case/CaseSectionHead";
 import NFTGallery from "../../Content/NFTGallery/NFTGallery";
 import OpenSeaGallery from "../../Content/NFTGallery/OpenSeaGallery";
 import NFTCollectionAnalytics from "../../Content/NFTCollectionAnalytics/NFTCollectionAnalytics";
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+import InViewMotion from "../../animation/InViewMotion";
 
 const Content = (props) => {
   const Content = styled.div`
@@ -127,7 +94,7 @@ const Content = (props) => {
           <OpenSeaGallery offset="0" limit="40" slug="the-fungible-by-pak" />
           <OpenSeaGallery offset="0" limit="2" slug="heraklit" />
 
-          <FadeInWhenVisible>
+          <InViewMotion>
             <NFTGallery
               eyebrow="Heraklit"
               eyebrowColor1="#FF0000"
@@ -138,8 +105,8 @@ const Content = (props) => {
               price="0.1"
               link="https://opensea.io/assets/matic/0x2953399124f0cbb46d2cbacd8a89cf0599974963/111589776352736674838778066049010664931120148642497133493220937301359675310081"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <NFTGallery
               eyebrow="Heraklit"
               eyebrowColor1="#FF0000"
@@ -150,8 +117,8 @@ const Content = (props) => {
               price="0.5"
               link="https://opensea.io/assets/matic/0x2953399124f0cbb46d2cbacd8a89cf0599974963/111589776352736674838778066049010664931120148642497133493220937301359675310081"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <NFTGallery
               eyebrow="Heraklit"
               eyebrowColor1="#FF0000"
@@ -162,8 +129,8 @@ const Content = (props) => {
               price="0.2"
               link="https://opensea.io/assets/matic/0x2953399124f0cbb46d2cbacd8a89cf0599974963/111589776352736674838778066049010664931120148642497133493220937301359675310081"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <NFTGallery
               eyebrow="Heraklit"
               eyebrowColor1="#FF0000"
@@ -174,8 +141,8 @@ const Content = (props) => {
               price="0.9"
               link="https://opensea.io/assets/matic/0x2953399124f0cbb46d2cbacd8a89cf0599974963/111589776352736674838778066049010664931120148642497133493220937301359675310081"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <NFTGallery
               eyebrow="Heraklit"
               eyebrowColor1="#FF0000"
@@ -186,8 +153,8 @@ const Content = (props) => {
               price="0.5"
               link="https://opensea.io/assets/matic/0x2953399124f0cbb46d2cbacd8a89cf0599974963/111589776352736674838778066049010664931120148642497133493220937301359675310081"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <NFTGallery
               eyebrow="Heraklit"
               eyebrowColor1="#FF0000"
@@ -198,8 +165,8 @@ const Content = (props) => {
               price="0.2"
               link="https://opensea.io/assets/matic/0x2953399124f0cbb46d2cbacd8a89cf0599974963/111589776352736674838778066049010664931120148642497133493220937301359675310081"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <NFTGallery
               eyebrow="Heraklit"
               eyebrowColor1="#FF0000"
@@ -210,8 +177,8 @@ const Content = (props) => {
               price="0.4"
               link="https://opensea.io/assets/matic/0x2953399124f0cbb46d2cbacd8a89cf0599974963/111589776352736674838778066049010664931120148642497133493220937301359675310081"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <NFTGallery
               eyebrow="Heraklit"
               eyebrowColor1="#FF0000"
@@ -222,7 +189,7 @@ const Content = (props) => {
               price="0.1"
               link="https://opensea.io/assets/matic/0x2953399124f0cbb46d2cbacd8a89cf0599974963/111589776352736674838778066049010664931120148642497133493220937301359675310081"
             />
-          </FadeInWhenVisible>
+          </InViewMotion>
         </NFTGalleryGrid>
       </Section>
     </Content>

--- a/src/components/Pages/Home/Home.js
+++ b/src/components/Pages/Home/Home.js
@@ -1,8 +1,5 @@
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import React, { useEffect } from "react";
-
-import { useInView } from "react-intersection-observer";
+import React from "react";
 
 import ReactGA from "react-ga4";
 
@@ -24,6 +21,7 @@ import { Check, X } from "lucide-react";
 import AccordeonVisual from "../../Content/AccordeonVisual/AccordeonVisual";
 import PricingCanvas from "../../Content/PricingCanvas/PricingCanvas";
 import Lightbox from "../../Lightbox/Lightbox";
+import InViewMotion from "../../animation/InViewMotion";
 import {
   DeliverablesGrid,
   PageContent,
@@ -172,80 +170,6 @@ const ROIImprovementValue = styled.div`
     font-size: 32px;
   }
 `;
-
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-  const [hasAnimated, setHasAnimated] = React.useState(false);
-
-  useEffect(() => {
-    if (inView && !hasAnimated) {
-      controls.start("visible");
-      setHasAnimated(true);
-    }
-  }, [controls, inView, hasAnimated]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
-
-function MoveUpWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-  const [hasAnimated, setHasAnimated] = React.useState(false);
-
-  useEffect(() => {
-    if (inView && !hasAnimated) {
-      controls.start("visible");
-      setHasAnimated(true);
-    }
-  }, [controls, inView, hasAnimated]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.6 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            when: "beforeChildren",
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-          transition: {
-            when: "afterChildren",
-          },
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 const Hero = styled.div`
   /* Auto Layout */
@@ -1587,25 +1511,25 @@ const Content = (props) => {
         </ProblemHeadline>
         <ProblemSubline>Does this sound familiar?</ProblemSubline>
         <ProblemList>
-          <MoveUpWhenVisible key="problem-1">
+          <InViewMotion variant="moveUp" key="problem-1">
             <ProblemListItem>
               <ProblemHighlight>Low Activation →</ProblemHighlight> New Users
               sign up but never reach their Aha Moment.
             </ProblemListItem>
-          </MoveUpWhenVisible>
+          </InViewMotion>
 
-          <MoveUpWhenVisible key="problem-2">
+          <InViewMotion variant="moveUp" key="problem-2">
             <ProblemListItem>
               <ProblemHighlight>Weak Retention →</ProblemHighlight> Even
               activated users drop off before forming habits.
             </ProblemListItem>
-          </MoveUpWhenVisible>
-          <MoveUpWhenVisible key="problem-3">
+          </InViewMotion>
+          <InViewMotion variant="moveUp" key="problem-3">
             <ProblemListItem>
               <ProblemHighlight>Poor Conversion →</ProblemHighlight> Too few
               free users upgrade to paid plans.
             </ProblemListItem>
-          </MoveUpWhenVisible>
+          </InViewMotion>
         </ProblemList>
         <ProblemConclusion>
           40% of startups die because of bad traction
@@ -1726,7 +1650,7 @@ const Content = (props) => {
         </SolutionSubline>
 
         <SolutionCards>
-          <FadeInWhenVisible>
+          <InViewMotion>
             <SolutionCard>
               <SolutionBody>
                 <SolutionParagraph>
@@ -1755,8 +1679,8 @@ const Content = (props) => {
                 <SolutionPicture src="./img/Landingpage/Solutions/Notes.png" />
               </SolutionBody>
             </SolutionCard>
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <SolutionCard>
               <SolutionBody>
                 <SolutionParagraph style={{ order: "2" }}>
@@ -1785,8 +1709,8 @@ const Content = (props) => {
                 <SolutionPicture src="./img/Landingpage/Solutions/Week2.png" />
               </SolutionBody>
             </SolutionCard>
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <SolutionCard>
               <SolutionBodyMac>
                 <SolutionParagraph>
@@ -1817,7 +1741,7 @@ const Content = (props) => {
                 <SolutionPictureBig src="./img/Landingpage/Solutions/Assessment1.png" />
               </SolutionBodyMac>
             </SolutionCard>
-          </FadeInWhenVisible>
+          </InViewMotion>
         </SolutionCards>
         <Lightbox
           isOpen={isROICalculatorOpen}
@@ -2287,15 +2211,15 @@ const Content = (props) => {
       <PaddedPageSection>
         <Headline2 headline="Questions? Answers." />
 
-        <MoveUpWhenVisible>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Establish empathy together as a team"
             //copy="It’s important to understand your users together as a team. Doing so eventually weaves benefit into the product at every level. By increasing your team’s exposure to users, you will increase the user’s satisfaction of the product."
             headline="Do you offer discounts?"
             copy="Yes! For Non-Profits I offer discounts. Please schedule a call and let's talk."
           />
-        </MoveUpWhenVisible>
-        <MoveUpWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Collectively define and agree on problems"
             //copy="Take time to understand and clearly define your user’s problems. Feeding the team solutions will only lead to demoralisation; people like being empowered and to have a chance to be creative. Let the team stretch their skills, and give them time to truly understand the problem."
@@ -2306,23 +2230,23 @@ A completed onboarding journey mapping canvas
 
 Wireframe mockups with detailed recommendations for updating your onboarding screens, user flows, and empty states."
           />
-        </MoveUpWhenVisible>
-        <MoveUpWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Prototype and test with real users"
             //copy="Fake it until you can make it. Spend the minimum amount of time to create the closest to the real thing. You’re looking for feedback on the idea, not whether your design looks finished. Test with real representative users."
             headline="How long does the process take?"
             copy="End-to-end, the process takes roughly two weeks to complete. However, this timeline is highly dependent on how quick and timely your team can provide feedback on our iterations. Be prepared to sync with your team in a timely manner in order to keep the final stage of the process moving forward."
           />
-        </MoveUpWhenVisible>
-        <MoveUpWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Group ideation"
             //copy="Good ideas can come from anyone. Waiting for one member of the team to create the best idea will take time, and will be biassed towards their experience. It doesn’t have to take long, there are exercises designed to generate lots of ideas quickly."
             headline="Can you also help with ongoing optimizations?"
             copy="Yes, I offer a retainer service to continuously refine, test and optimize your onboarding flow and other user journeys based on real user data and feedback. I also advise in other areas of product-led growth."
           />
-        </MoveUpWhenVisible>
+        </InViewMotion>
       </PaddedPageSection>
       <PaddedPageSection>
         <Hero>

--- a/src/components/Pages/Portfolio/MyKnauf.js
+++ b/src/components/Pages/Portfolio/MyKnauf.js
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
-import { useInView } from "react-intersection-observer";
 
 //Components
 import { Colors, Devices } from "../../DesignSystem";
@@ -18,39 +16,7 @@ import CaseTitleEyebrow from "../../Content/Case/CaseTitleEyebrow";
 
 import CaseCard from "../../Content/CaseCard/CaseCard";
 import Drawer from "../../Content/Drawer/Drawer";
-
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+import InViewMotion from "../../animation/InViewMotion";
 
 const Content = (props) => {
   const galleryItems = [
@@ -351,7 +317,7 @@ const Content = (props) => {
         <Paragraph>
           <CaseSectionHead headline={"Other Projects"} />
           <CaseCardGrid>
-            <FadeInWhenVisible>
+            <InViewMotion>
               <CaseCard
                 eyebrow="Case Study"
                 eyebrowColor2="#231768"
@@ -361,8 +327,8 @@ const Content = (props) => {
                 imgURL="./img/Knauf/CoverKnaufTransformation.png"
                 link="/knauf-explorations"
               />
-            </FadeInWhenVisible>
-            <FadeInWhenVisible>
+            </InViewMotion>
+            <InViewMotion>
               <CaseCard
                 eyebrow="Case Study"
                 eyebrowColor2="#231768"
@@ -372,8 +338,8 @@ const Content = (props) => {
                 imgURL="./img/Knauf/CoverMyKnauf.png"
                 link="/myKnauf"
               />
-            </FadeInWhenVisible>
-            <FadeInWhenVisible>
+            </InViewMotion>
+            <InViewMotion>
               <CaseCard
                 eyebrow="Deep Dive"
                 eyebrowColor2="#231768"
@@ -383,8 +349,8 @@ const Content = (props) => {
                 imgURL="./img/Knauf/CoverProductAnalytics.png"
                 comingSoon="true"
               />
-            </FadeInWhenVisible>
-            <FadeInWhenVisible>
+            </InViewMotion>
+            <InViewMotion>
               <CaseCard
                 eyebrow="Deep Dive"
                 eyebrowColor2="#231768"
@@ -394,8 +360,8 @@ const Content = (props) => {
                 imgURL="./img/Knauf/CoverUserAcquisition.png"
                 comingSoon="true"
               />
-            </FadeInWhenVisible>
-            <FadeInWhenVisible>
+            </InViewMotion>
+            <InViewMotion>
               <CaseCard
                 eyebrow="Deep Dive"
                 eyebrowColor2="#231768"
@@ -405,8 +371,8 @@ const Content = (props) => {
                 imgURL="./img/Knauf/CoverSignup.png"
                 link="/knauf-account"
               />
-            </FadeInWhenVisible>
-            <FadeInWhenVisible>
+            </InViewMotion>
+            <InViewMotion>
               <CaseCard
                 eyebrow="Deep Dive"
                 eyebrowColor2="#231768"
@@ -416,7 +382,7 @@ const Content = (props) => {
                 imgURL="./img/Knauf/CoverUserRetention.png"
                 link="/knauf-orderoverview"
               />
-            </FadeInWhenVisible>
+            </InViewMotion>
           </CaseCardGrid>
         </Paragraph>
       </Section>

--- a/src/components/Pages/Portfolio/Portfolio.js
+++ b/src/components/Pages/Portfolio/Portfolio.js
@@ -1,8 +1,6 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import { useInView } from "react-intersection-observer";
 
 //Components
 import { Devices } from "../../DesignSystem";
@@ -10,39 +8,7 @@ import SectionHead from "../../Content/Section/SectionHead";
 
 import CaseCard from "../../Content/CaseCard/CaseCard";
 import CaseSectionSummary from "../../Content/Case/CaseSectionSummary";
-
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+import InViewMotion from "../../animation/InViewMotion";
 
 const Content = (props) => {
   const Content = styled.div`
@@ -145,16 +111,16 @@ const Content = (props) => {
           subline="Building a global apps platform, from scratch."
         />
         <Panels style={{ marginBottom: "48px" }}>
-          <FadeInWhenVisible>
+          <InViewMotion>
             <CaseSectionSummary
               copy="
 As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construction apps, creating a unified design system. I established key growth metrics for these products, leading to data-informed decisions."
               //imgURL="./img/PanelTestImages/one.jpg"
             />
-          </FadeInWhenVisible>
+          </InViewMotion>
         </Panels>
         <CaseCardGrid>
-          <FadeInWhenVisible>
+          <InViewMotion>
             <CaseCard
               eyebrow="Case Study"
               eyebrowColor2="#231768"
@@ -164,8 +130,8 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
               imgURL="./img/Knauf/CoverKnaufTransformation.png"
               link="/knauf-explorations"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <CaseCard
               eyebrow="Case Study"
               eyebrowColor2="#231768"
@@ -175,8 +141,8 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
               imgURL="./img/Knauf/CoverMyKnauf.png"
               link="/myKnauf"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <CaseCard
               eyebrow="Deep Dive"
               eyebrowColor2="#231768"
@@ -186,8 +152,8 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
               imgURL="./img/Knauf/CoverProductAnalytics.png"
               comingSoon="true"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <CaseCard
               eyebrow="Deep Dive"
               eyebrowColor2="#231768"
@@ -197,8 +163,8 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
               imgURL="./img/Knauf/CoverUserAcquisition.png"
               comingSoon="true"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <CaseCard
               eyebrow="Deep Dive"
               eyebrowColor2="#231768"
@@ -208,8 +174,8 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
               imgURL="./img/Knauf/CoverSignup.png"
               link="/knauf-account"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <CaseCard
               eyebrow="Deep Dive"
               eyebrowColor2="#231768"
@@ -219,7 +185,7 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
               imgURL="./img/Knauf/CoverUserRetention.png"
               link="/knauf-orderoverview"
             />
-          </FadeInWhenVisible>
+          </InViewMotion>
         </CaseCardGrid>
       </Section>
 
@@ -234,16 +200,16 @@ As the Chapter Lead UX, I spearheaded the design and UX for four Knauf construct
             gap: "24px",
           }}
         >
-          <FadeInWhenVisible>
+          <InViewMotion>
             <CaseSectionSummary
               copy="
 As the Chapter Lead UX, I led the product design of Knauf's global websites unification, establishing a cohesive design system across 4 product teams. A successful launch in 120 countries and multiple languages, guided by key performance metrics analysis."
               //imgURL="./img/PanelTestImages/one.jpg"
             />
-          </FadeInWhenVisible>
+          </InViewMotion>
         </Panels>
         <CaseCardGrid>
-          <FadeInWhenVisible>
+          <InViewMotion>
             <CaseCard
               eyebrow="Case Study"
               eyebrowColor1="#3b177d"
@@ -253,8 +219,8 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               imgURL="./img/Knauf/CoverKnaufCom.png"
               comingSoon="true"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <CaseCard
               eyebrow="Deep Dive"
               eyebrowColor1="#3b177d"
@@ -264,8 +230,8 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               imgURL="./img/Knauf/CoverProductWorkflow.png"
               comingSoon="true"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <CaseCard
               eyebrow="Deep Dive"
               eyebrowColor1="#3b177d"
@@ -275,7 +241,7 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               imgURL="./img/Knauf/CoverUXMetrics.png"
               comingSoon="true"
             />
-          </FadeInWhenVisible>
+          </InViewMotion>
         </CaseCardGrid>
       </Section>
       <Section>
@@ -284,15 +250,15 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
           subline="Leading the digital relaunch of a premium lighting brand."
         />
         <Panels style={{ marginBottom: "48px" }}>
-          <FadeInWhenVisible>
+          <InViewMotion>
             <CaseSectionSummary
               copy="As the UX Manager & Product Owner, I led Occhio's website relaunch and e-commerce debut, blending brand, user experience and performance to redefine Occhio's digital presence. This overhaul boosted user engagement and conversion rates, earning accolades and raising e-commerce to 10% of revenue share"
               //imgURL="./img/PanelTestImages/one.jpg"
             />
-          </FadeInWhenVisible>
+          </InViewMotion>
         </Panels>
         <CaseCardGrid>
-          <FadeInWhenVisible>
+          <InViewMotion>
             <CaseCard
               eyebrow="Case Study"
               eyebrowColor1="#FF0000"
@@ -303,13 +269,13 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               imgURL="./img/Occhio/Occhio-Website.png"
               link="/occhio"
             />
-          </FadeInWhenVisible>
+          </InViewMotion>
         </CaseCardGrid>
       </Section>
       <Section>
         <SectionHead divider="Side Projects" />
         <CaseCardGrid>
-          <FadeInWhenVisible>
+          <InViewMotion>
             <CaseCard
               eyebrow="Website / eCommerce"
               eyebrowColor2="#d9edca"
@@ -319,8 +285,8 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               imgURL="./img/FeatheredHooks/CoverFeatheredHooks.png"
               link="/feathered-hooks"
             />
-          </FadeInWhenVisible>
-          <FadeInWhenVisible>
+          </InViewMotion>
+          <InViewMotion>
             <CaseCard
               eyebrow="App"
               eyebrowColor2="#6a210d"
@@ -330,7 +296,7 @@ As the Chapter Lead UX, I led the product design of Knauf's global websites unif
               imgURL="./img/CookCook/CoverCookCook.png"
               link="https://www.cookcook.it/"
             />
-          </FadeInWhenVisible>
+          </InViewMotion>
         </CaseCardGrid>
       </Section>
     </Content>

--- a/src/components/Pages/Profile/Profile.js
+++ b/src/components/Pages/Profile/Profile.js
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled";
-import { motion, useAnimation } from "framer-motion";
-import React, { useEffect } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
-import { useInView } from "react-intersection-observer";
 import Trend from "react-trend";
 
 //Components
@@ -20,113 +18,7 @@ import Button from "../../Button/Button";
 import { mdiFilePdfBox } from "@mdi/js";
 import BusinessCard from "../../Content/BusinessCard/BusinessCard";
 import { mdiEmail } from "@mdi/js";
-
-function FadeInWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.3 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
-
-function MoveUpWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.6 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            when: "beforeChildren",
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-          transition: {
-            when: "afterChildren",
-          },
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
-
-function RevealWhenVisible({ children }) {
-  const controls = useAnimation();
-  const [ref, inView] = useInView();
-
-  useEffect(() => {
-    if (inView) {
-      controls.start("visible");
-    }
-  }, [controls, inView]);
-
-  return (
-    <motion.div
-      ref={ref}
-      animate={controls}
-      initial="hidden"
-      transition={{ duration: 0.9 }}
-      variants={{
-        visible: {
-          opacity: 1,
-          transition: {
-            when: "beforeChildren",
-            staggerChildren: 0.3,
-          },
-        },
-        hidden: {
-          opacity: 0,
-          transition: {
-            when: "afterChildren",
-          },
-        },
-      }}
-    >
-      {children}
-    </motion.div>
-  );
-}
+import InViewMotion from "../../animation/InViewMotion";
 
 const Content = (props) => {
   const Content = styled.div`
@@ -340,39 +232,39 @@ const Content = (props) => {
           headline={"Alexandros Shomper"}
           copy="I’m an outcome oriented, remote-first product lead with 15+ years of experience in a variety of B2B and B2C industries - from Startup environment to Corporate."
         />
-        <RevealWhenVisible>
+        <InViewMotion variant="reveal">
           <SectionDivider text={"Here’s a TL;DR of my career:"} />
-        </RevealWhenVisible>
-        <RevealWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="reveal">
           <SectionCopy
             copy={
               "Education in Arts & Marketing, and self-taught developer 👨🏻‍💻 (still building own side projects)"
             }
           />
-        </RevealWhenVisible>
-        <RevealWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="reveal">
           <SectionCopy
             copy={
               "Successful career in advertising and marketing, creating global marketing campaigns and brand experiences"
             }
           />
-        </RevealWhenVisible>
-        <RevealWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="reveal">
           <SectionCopy
             copy={
               "Extensive experience growing products and teams 🚀 in all stages of enterprises from Product-Market-Fit, to Product Led Growth to Core Product Work"
             }
           />
-        </RevealWhenVisible>
-        <RevealWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="reveal">
           <SectionCopy
             copy={
               "I have a passion for outcome 🎯 by developing and enhancing data-driven and customer-centric processes and culture"
             }
           />
-        </RevealWhenVisible>
+        </InViewMotion>
 
-        <RevealWhenVisible>
+        <InViewMotion variant="reveal">
           <AnnotationWrapper
             style={{ color: Colors.primaryText.mediumEmphasis }}
           >
@@ -419,14 +311,14 @@ const Content = (props) => {
               icon={mdiFilePdfBox}
             />
           </AnnotationWrapper>
-        </RevealWhenVisible>
+        </InViewMotion>
       </Section>
       <Section>
         <SectionHead
           headline="Human Centered Leadership"
           subline="I believe happy and healthy teams are the most productive, and innovative teams."
         />
-        <FadeInWhenVisible>
+        <InViewMotion>
           <CardPanels>
             <ListPanel
               eyebrow="Autonomy"
@@ -452,14 +344,14 @@ const Content = (props) => {
               //imgURL="./img/PanelTestImages/two.jpg"
             />
           </CardPanels>
-        </FadeInWhenVisible>
+        </InViewMotion>
       </Section>
       <Section>
         <SectionHead
           headline="My Principles"
           subline="Give meaning to actions and ideas."
         />
-        <FadeInWhenVisible>
+        <InViewMotion>
           <CardPanels>
             <ListPanel
               eyebrow="Data Driven/Informed"
@@ -497,7 +389,7 @@ const Content = (props) => {
               //imgURL="./img/PanelTestImages/two.jpg"
             />
           </CardPanels>
-        </FadeInWhenVisible>
+        </InViewMotion>
       </Section>
 
       <Section>
@@ -563,39 +455,39 @@ const Content = (props) => {
           copy="Innovative products need a flexible but repeatable process of making data-driven & customer-centric product decisions."
           //copy="Aproaching problems creatively with well-though and well-executed solutions. Developing feasibility, desirability and viability ideas that improve people's life in some manner, but at the same time it needs to be work and make business sense."
         />
-        <MoveUpWhenVisible>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Establish empathy together as a team"
             //copy="It’s important to understand your users together as a team. Doing so eventually weaves benefit into the product at every level. By increasing your team’s exposure to users, you will increase the user’s satisfaction of the product."
             headline="Discover"
             copy="It all starts with observing, learning, and understanding. Understand the business, the brand and the users. Frame the problem and validate it. Distill and weight the user insights and hypotheses. What are we aiming for?"
           />
-        </MoveUpWhenVisible>
-        <MoveUpWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Collectively define and agree on problems"
             //copy="Take time to understand and clearly define your user’s problems. Feeding the team solutions will only lead to demoralisation; people like being empowered and to have a chance to be creative. Let the team stretch their skills, and give them time to truly understand the problem."
             headline="Define"
             copy="Goals become actions. What are the Use Cases, how do the Personae & the Journey look like. Identify the most important touchpoints. Which strategic models can be used to bring business, brand, and user together."
           />
-        </MoveUpWhenVisible>
-        <MoveUpWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Prototype and test with real users"
             //copy="Fake it until you can make it. Spend the minimum amount of time to create the closest to the real thing. You’re looking for feedback on the idea, not whether your design looks finished. Test with real representative users."
             headline="Design"
             copy="Pick the most important touchpoints and hypotheses. Start building and testing. Build desire and loyalty. Users will only stick around, if you can turn your findings to an unforgettable experience."
           />
-        </MoveUpWhenVisible>
-        <MoveUpWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Group ideation"
             //copy="Good ideas can come from anyone. Waiting for one member of the team to create the best idea will take time, and will be biassed towards their experience. It doesn’t have to take long, there are exercises designed to generate lots of ideas quickly."
             headline="Develop"
             copy="Now it's time to manifest the user experience. Pick an essential set of features to launch the product with to get the ball rolling. Translate the design into code, and keep an eye on the quality of the outcome. Learn. Iterate."
           />
-        </MoveUpWhenVisible>
-        <MoveUpWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Establish empathy together as a team"
             //copy="It’s important to understand your users together as a team. Doing so eventually weaves benefit into the product at every level. By increasing your team’s exposure to users, you will increase the user’s satisfaction of the product."
@@ -603,8 +495,8 @@ const Content = (props) => {
             headline="Deliver"
             copy="It's about implementing the product in the operating team. Put the pieces in place so that everybody is on board and speaks the same language. Create style guides, user experience guidelines, and documentation. Bring clarity without being too restrictive."
           />
-        </MoveUpWhenVisible>
-        <MoveUpWhenVisible>
+        </InViewMotion>
+        <InViewMotion variant="moveUp">
           <ListBigText
             //headline="Iterate, iterate, iterate"
             //copy="It isn’t enough to run through a design process once. Learn from your users, learn from your team, and iterate. Your process will mature and you’ll be able to run through it easier and faster on each pass. Being agile is to be set up to react to new information fast."
@@ -612,7 +504,7 @@ const Content = (props) => {
             headline="Distribute"
             copy="Measure the performance of the product, and the engagement of the users. Learn. Iterate. Iterate. Iterate. Find out what attracts new users. Continuously work on the Aha-Moment & Stickiness to drive retention and loyalty."
           />
-        </MoveUpWhenVisible>
+        </InViewMotion>
       </Section>
     </Content>
   );

--- a/src/components/animation/InViewMotion.js
+++ b/src/components/animation/InViewMotion.js
@@ -1,0 +1,195 @@
+import React, { useCallback, useEffect, useMemo } from "react";
+import { motion, useAnimation } from "framer-motion";
+import { useInView } from "react-intersection-observer";
+
+const buildFadeVariants = ({ duration, staggerChildren } = {}) => {
+  const effectiveDuration = duration ?? 0.3;
+  const effectiveStagger =
+    staggerChildren !== undefined ? staggerChildren : 0.3;
+
+  const visibleTransition = {};
+  if (effectiveStagger !== undefined && effectiveStagger !== null) {
+    visibleTransition.staggerChildren = effectiveStagger;
+  }
+
+  return {
+    transition: { duration: effectiveDuration },
+    variants: {
+      visible: {
+        opacity: 1,
+        transition: visibleTransition,
+      },
+      hidden: {
+        opacity: 0,
+      },
+    },
+  };
+};
+
+const buildMoveUpVariants = ({ duration, staggerChildren, offset } = {}) => {
+  const effectiveDuration = duration ?? 0.6;
+  const effectiveStagger =
+    staggerChildren !== undefined ? staggerChildren : 0.3;
+  const effectiveOffset = offset ?? 0;
+
+  const visibleTransition = {
+    when: "beforeChildren",
+  };
+  if (effectiveStagger !== undefined && effectiveStagger !== null) {
+    visibleTransition.staggerChildren = effectiveStagger;
+  }
+
+  return {
+    transition: { duration: effectiveDuration },
+    variants: {
+      visible: {
+        opacity: 1,
+        y: 0,
+        transition: visibleTransition,
+      },
+      hidden: {
+        opacity: 0,
+        y: effectiveOffset,
+        transition: {
+          when: "afterChildren",
+        },
+      },
+    },
+  };
+};
+
+const buildRevealVariants = ({ duration, staggerChildren } = {}) => {
+  const effectiveDuration = duration ?? 0.9;
+  const effectiveStagger =
+    staggerChildren !== undefined ? staggerChildren : 0.3;
+
+  const visibleTransition = {
+    when: "beforeChildren",
+  };
+  if (effectiveStagger !== undefined && effectiveStagger !== null) {
+    visibleTransition.staggerChildren = effectiveStagger;
+  }
+
+  return {
+    transition: { duration: effectiveDuration },
+    variants: {
+      visible: {
+        opacity: 1,
+        transition: visibleTransition,
+      },
+      hidden: {
+        opacity: 0,
+        transition: {
+          when: "afterChildren",
+        },
+      },
+    },
+  };
+};
+
+const VARIANT_BUILDERS = {
+  fade: buildFadeVariants,
+  moveUp: buildMoveUpVariants,
+  reveal: buildRevealVariants,
+};
+
+const InViewMotion = React.forwardRef(
+  (
+    {
+      children,
+      variant = "fade",
+      duration,
+      staggerChildren,
+      offset,
+      transition: transitionOverride = {},
+      visible: visibleOverride = {},
+      hidden: hiddenOverride = {},
+      triggerOnce = true,
+      threshold,
+      rootMargin,
+      reset = false,
+      onInView,
+      onOutOfView,
+      ...rest
+    },
+    forwardedRef
+  ) => {
+    const controls = useAnimation();
+    const [inViewRef, inView] = useInView({
+      triggerOnce,
+      threshold,
+      rootMargin,
+    });
+
+    const setRefs = useCallback(
+      (node) => {
+        inViewRef(node);
+        if (typeof forwardedRef === "function") {
+          forwardedRef(node);
+        } else if (forwardedRef) {
+          forwardedRef.current = node;
+        }
+      },
+      [inViewRef, forwardedRef]
+    );
+
+    useEffect(() => {
+      if (inView) {
+        controls.start("visible");
+        onInView?.();
+      } else if (reset && !triggerOnce) {
+        controls.start("hidden");
+        onOutOfView?.();
+      } else if (!inView) {
+        onOutOfView?.();
+      }
+    }, [controls, inView, onInView, onOutOfView, reset, triggerOnce]);
+
+    const config = useMemo(() => {
+      const builder = VARIANT_BUILDERS[variant] || VARIANT_BUILDERS.fade;
+      return builder({ duration, staggerChildren, offset });
+    }, [variant, duration, staggerChildren, offset]);
+
+    const transition = useMemo(
+      () => ({
+        ...config.transition,
+        ...transitionOverride,
+      }),
+      [config, transitionOverride]
+    );
+
+    const variants = useMemo(() => {
+      const visibleVariant = {
+        ...config.variants.visible,
+        ...visibleOverride,
+      };
+      const hiddenVariant = {
+        ...config.variants.hidden,
+        ...hiddenOverride,
+      };
+
+      return {
+        visible: visibleVariant,
+        hidden: hiddenVariant,
+      };
+    }, [config, visibleOverride, hiddenOverride]);
+
+    return (
+      <motion.div
+        ref={setRefs}
+        initial="hidden"
+        animate={controls}
+        transition={transition}
+        variants={variants}
+        {...rest}
+      >
+        {children}
+      </motion.div>
+    );
+  }
+);
+
+InViewMotion.displayName = "InViewMotion";
+
+export default InViewMotion;
+export { VARIANT_BUILDERS as inViewMotionVariants };


### PR DESCRIPTION
## Summary
- add a shared InViewMotion helper built on useInView/useAnimation with configurable fade, moveUp, and reveal variants
- replace inline FadeInWhenVisible/MoveUpWhenVisible wrappers across home, profile, portfolio, heraklit, flows, landing head, and flip card components to use the shared helper

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d3a2d5a6fc8327a508be1d0c9210ce