### PR TITLE
Align case and report headlines with shared styles

### DIFF
--- a/src/components/Content/Case/CaseSubline.js
+++ b/src/components/Content/Case/CaseSubline.js
@@ -1,38 +1,9 @@
 import React from "react";
-import styled from "@emotion/styled";
 
-import { Devices, Colors } from "../../DesignSystem";
+import { ArticleSubline } from "../../DesignSystem";
 
 const CaseSubline = ({ subline }) => {
-  const CaseSubline = styled.p`
-    font-family: "Roboto", sans-serif;
-    font-weight: bold;
-    font-style: normal;
-
-    color: ${Colors.primaryText.mediumEmphasis};
-    margin-bottom: 8px;
-    margin-top: 0px;
-
-    font-size: 28px;
-    line-height: 112%;
-    text-align: left;
-    width: 90%;
-    ${Devices.tabletS} {
-      width: 564px;
-      font-size: 36px;
-      line-height: 112%;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-
-  return <CaseSubline>{subline}</CaseSubline>;
+  return <ArticleSubline>{subline}</ArticleSubline>;
 };
 
 export default CaseSubline;

--- a/src/components/Content/Case/CaseTitle.js
+++ b/src/components/Content/Case/CaseTitle.js
@@ -1,55 +1,9 @@
 import React from "react";
-import styled from "@emotion/styled";
 
-import { Devices, Colors } from "../../DesignSystem";
+import { ArticleHeadline } from "../../DesignSystem";
 
 const CaseTitle = ({ headline }) => {
-  const CaseTitle = styled.h1`
-    direction: ltr;
-    display: block;
-
-    list-style-image: none;
-    list-style-position: outside;
-    list-style-type: none;
-
-    padding: 0px;
-    margin-block-end: 4px;
-    margin-block-start: 0px;
-    margin-bottom: 4x;
-    margin-inline-end: 0px;
-    margin-inline-start: 0px;
-    margin-left: 0px;
-    margin-right: 0px;
-    margin-top: 0px;
-
-    text-align: left;
-    text-decoration-thickness: auto;
-    text-size-adjust: 100%;
-    -webkit-box-direction: normal;
-    -webkit-font-smoothing: antialiased;
-    font-weight: 700;
-    font-size: 36px;
-    line-height: 120%;
-    width: 90%;
-
-    color: ${Colors.primaryText};
-
-    margin-top: 0px;
-
-    ${Devices.tabletS} {
-      width: 564px;
-      font-size: 56px;
-      line-height: 120%;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-    }
-    ${Devices.laptopS} {
-      width: 740px;
-    }
-  `;
-
-  return <CaseTitle>{headline}</CaseTitle>;
+  return <ArticleHeadline>{headline}</ArticleHeadline>;
 };
 
 export default CaseTitle;

--- a/src/components/Content/Report/ReportSubline.js
+++ b/src/components/Content/Report/ReportSubline.js
@@ -1,39 +1,9 @@
 import React from "react";
-import styled from "@emotion/styled";
 
-import { Devices, Colors } from "../../DesignSystem";
+import { ArticleSubline } from "../../DesignSystem";
 
 const ReportSubline = ({ subline }) => {
-  const ReportSubline = styled.p`
-    font-family: "Roboto", sans-serif;
-    font-weight: 550;
-    font-style: normal;
-    letter-spacing: 0.04rem;
-
-    color: ${Colors.primaryText.mediumEmphasis};
-    margin-bottom: 8px;
-    margin-top: 0px;
-
-    font-size: 28px;
-    line-height: 112%;
-    text-align: left;
-    width: 90%;
-    ${Devices.tabletS} {
-      width: 520px;
-      font-size: 36px;
-      line-height: 112%;
-    }
-    ${Devices.tabletM} {
-      width: 520px;
-    }
-    ${Devices.laptopS} {
-      width: 650px;
-    }
-    ${Devices.laptopM} {
-    }
-  `;
-
-  return <ReportSubline>{subline}</ReportSubline>;
+  return <ArticleSubline>{subline}</ArticleSubline>;
 };
 
 export default ReportSubline;

--- a/src/components/Content/Report/ReportTitle.js
+++ b/src/components/Content/Report/ReportTitle.js
@@ -1,54 +1,9 @@
 import React from "react";
-import styled from "@emotion/styled";
 
-import { Devices, Colors } from "../../DesignSystem";
+import { ArticleHeadline } from "../../DesignSystem";
 
 const ReportTitle = ({ headline }) => {
-  const ReportTitle = styled.h1`
-    direction: ltr;
-    display: block;
-
-    list-style-image: none;
-    list-style-position: outside;
-    list-style-type: none;
-
-    padding: 0px;
-    margin-block-end: 4px;
-    margin-block-start: 0px;
-    margin-bottom: 4x;
-    margin-inline-end: 0px;
-    margin-inline-start: 0px;
-    margin-left: 0px;
-    margin-right: 0px;
-    margin-top: 0px;
-
-    text-align: left;
-    text-decoration-thickness: auto;
-    text-size-adjust: 100%;
-    -webkit-box-direction: normal;
-    -webkit-font-smoothing: antialiased;
-    font-weight: 500;
-    font-size: 36px;
-    line-height: 120%;
-    width: 90%;
-
-    color: ${Colors.primaryText};
-
-    margin-top: 0px;
-
-    ${Devices.tabletS} {
-      width: 520px;
-      font-size: 50px;
-      line-height: 120%;
-    }
-    ${Devices.tabletM} {
-      width: 520px;
-    }
-    ${Devices.laptopS} {
-      width: 650px;
-  `;
-
-  return <ReportTitle>{headline}</ReportTitle>;
+  return <ArticleHeadline>{headline}</ArticleHeadline>;
 };
 
 export default ReportTitle;

--- a/src/components/DesignSystem.js
+++ b/src/components/DesignSystem.js
@@ -318,3 +318,59 @@ export const ArticleSection = styled.section`
 ArticleSection.defaultProps = {
   "data-article-section": true,
 };
+
+export const ArticleHeadline = styled.h1`
+  direction: ltr;
+  display: block;
+  margin: 0 0 4px;
+
+  text-align: left;
+  -webkit-font-smoothing: antialiased;
+  font-weight: 500;
+  font-size: 36px;
+  line-height: 120%;
+  width: 90%;
+  color: ${Colors.primaryText.highEmphasis};
+
+  ${Devices.tabletS} {
+    width: 520px;
+    font-size: 50px;
+    line-height: 120%;
+  }
+
+  ${Devices.tabletM} {
+    width: 520px;
+  }
+
+  ${Devices.laptopS} {
+    width: 650px;
+  }
+`;
+
+export const ArticleSubline = styled.p`
+  font-family: "Roboto", sans-serif;
+  font-style: normal;
+  font-weight: 550;
+  letter-spacing: 0.04rem;
+  margin: 0 0 8px;
+
+  color: ${Colors.primaryText.mediumEmphasis};
+  font-size: 28px;
+  line-height: 112%;
+  text-align: left;
+  width: 90%;
+
+  ${Devices.tabletS} {
+    width: 520px;
+    font-size: 36px;
+    line-height: 112%;
+  }
+
+  ${Devices.tabletM} {
+    width: 520px;
+  }
+
+  ${Devices.laptopS} {
+    width: 650px;
+  }
+`;


### PR DESCRIPTION
## Summary
- add shared ArticleHeadline and ArticleSubline components to the design system
- refactor case study and report title/subline components to reuse the shared styles

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d968fb21ec8327aadad98a23a5810f