### PR TITLE
Adjust flow gallery slider for mobile

### DIFF
--- a/src/components/Content/FlowCarousel/FlowCarousel.js
+++ b/src/components/Content/FlowCarousel/FlowCarousel.js
@@ -25,6 +25,12 @@ const CarouselViewport = styled.div`
   border-radius: inherit;
   width: 100%;
   height: 100%;
+  scroll-snap-type: x mandatory;
+  scroll-padding: 0 20px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const CarouselContent = styled.div`
@@ -33,11 +39,12 @@ const CarouselContent = styled.div`
 
 const CarouselGrid = styled.div`
   display: flex;
-  gap: 24px;
+  gap: 16px;
   padding: 4px 20px 10px 20px;
-  width: min-content;
+  width: max-content;
 
   ${Devices.tabletS} {
+    gap: 24px;
     padding: 4px 330px 10px 330px;
   }
 `;

--- a/src/components/Content/FlowCarousel/FlowItem.js
+++ b/src/components/Content/FlowCarousel/FlowItem.js
@@ -5,34 +5,43 @@ import { Colors, Devices } from "../../DesignSystem";
 
 const FlowItemCard = styled.div`
   border-radius: 12px;
-  width: 480px;
+  width: 70%;
   height: 100%;
   margin: 0;
-  display: block;
+  display: flex;
+  flex-direction: column;
   flex-shrink: 0;
   overflow: hidden;
   border-color: rgb(194, 194, 194);
   border-width: 1px;
   border-style: solid;
+  scroll-snap-align: center;
+
+  &:first-of-type {
+    scroll-snap-align: start;
+  }
+
+  &:last-of-type {
+    scroll-snap-align: end;
+  }
+
+  ${Devices.tabletS} {
+    width: 480px;
+  }
 `;
 
 const FlowItemWrapper = styled.div`
-  position: relative;
   width: 100%;
-  aspect-ratio: 8 / 5;
 `;
 
 const FlowItemLink = styled.a`
   display: flex;
-  position: absolute;
-  inset: 0px;
   border-radius: 12px;
 
   overflow: hidden;
   cursor: zoom-in;
 
   width: 100%;
-  height: 100%;
 
   &:hover {
     color: ${Colors.primaryText.highEmphasis};
@@ -45,23 +54,17 @@ const FlowItemLink = styled.a`
 
 const FlowItemImage = styled.div`
   flex-grow: 1;
-
-  ${Devices.tabletS} {
-  }
-  ${Devices.tabletM} {
-  }
-  ${Devices.laptopS} {
-  }
-  ${Devices.laptopM} {
-  }
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 const FlowItemPicture = styled.img`
   border-radius: 12px;
-  object-position: top;
-  object-fit: cover;
+  object-fit: contain;
   width: 100%;
-  height: 100%;
+  height: auto;
+  display: block;
 `;
 
 const FlowItem = ({ image }) => {


### PR DESCRIPTION
## Summary
- add horizontal scroll snapping to the flow gallery carousel viewport and adjust mobile spacing
- update flow gallery item styling to preserve screenshot aspect ratios and set mobile card width to 70% with scroll snap alignment rules

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68da32f10458832782f12559703cc155