### PR TITLE
Consolidate overview typography styles into DesignSystem

### DIFF
--- a/src/components/Content/Case/CaseSectionSummary.js
+++ b/src/components/Content/Case/CaseSectionSummary.js
@@ -1,39 +1,11 @@
 import React from "react";
-import styled from "@emotion/styled";
-
-import { Devices } from "../../DesignSystem";
-
-import Copy from "../List/ListSmallText/ListSmallTextCopy";
+import { OverviewPages } from "../../DesignSystem";
 
 const CaseSectionSummary = ({ copy }) => {
-  const CaseSectionSummary = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-
-    text-align: left;
-
-    margin: 0px 24px 60px 24px;
-    &:last-child {
-      margin-bottom: 0px;
-    }
-
-    //padding-right: 12px;
-
-    ${Devices.tabletS} {
-      width: 100%;
-      margin: 0px 0px 60px 0px;
-    }
-    ${Devices.tabletM} {
-      width: 90%;
-    }
-    ${Devices.laptop} {
-      width: 80%;
-    }
-  `;
-
   return (
-    <CaseSectionSummary>{copy && <Copy text={copy} />}</CaseSectionSummary>
+    <OverviewPages.Summary>
+      {copy ? <OverviewPages.Copy>{copy}</OverviewPages.Copy> : null}
+    </OverviewPages.Summary>
   );
 };
 

--- a/src/components/Content/Section/SectionCopy.js
+++ b/src/components/Content/Section/SectionCopy.js
@@ -1,50 +1,8 @@
 import React from "react";
-import styled from "@emotion/styled";
-
-import { Devices, Colors } from "../../DesignSystem";
-
-const SectionCopyText = styled.p`
-  font-family: "Roboto", sans-serif;
-  font-style: normal;
-  font-weight: normal;
-  color: ${Colors.primaryText.highEmphasis};
-  margin: 0px 24px 24px 24px;
-
-  font-size: 20px;
-  line-height: 120%;
-  text-align: left;
-
-  ${Devices.tabletS} {
-    text-align: left;
-    width: 576px;
-  }
-  ${Devices.tabletM} {
-    width: 720px;
-
-    font-size: 36px;
-    line-height: 111%;
-    margin-bottom: 32px;
-    margin-left: 0px;
-    margin-right: 0px;
-  }
-  ${Devices.laptopS} {
-    width: 864px;
-
-    font-size: 36px;
-    line-height: 100%;
-    margin-bottom: 38px;
-  }
-  ${Devices.laptopM} {
-    width: 1152px;
-
-    font-size: 42px;
-    line-height: 113%;
-    margin-bottom: 46px;
-  }
-`;
+import { OverviewPages } from "../../DesignSystem";
 
 const SectionCopy = ({ copy }) => {
-  return <SectionCopyText>{copy}</SectionCopyText>;
+  return <OverviewPages.Copy>{copy}</OverviewPages.Copy>;
 };
 
 export default SectionCopy;

--- a/src/components/Content/Section/SectionHeadline.js
+++ b/src/components/Content/Section/SectionHeadline.js
@@ -1,46 +1,8 @@
 import React from "react";
-import styled from "@emotion/styled";
-
-import { Devices, Colors } from "../../DesignSystem";
+import { OverviewPages } from "../../DesignSystem";
 
 const SectionHeadline = ({ headline }) => {
-  const SectionHeadline = styled.h2`
-    font-family: "Roboto", sans-serif;
-    font-weight: bold;
-    font-style: normal;
-
-    color: ${Colors.primaryText.highEmphasis};
-    margin-bottom: 8px;
-    margin-top: 0px;
-
-    font-size: 44px;
-    line-height: 109%;
-    text-align: left;
-    ${Devices.tabletS} {
-      text-align: left;
-      width: 564px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-
-      font-size: 44px;
-      line-height: 114%;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-
-      font-size: 64px;
-      line-height: 131%;
-    }
-    ${Devices.laptopM} {
-      width: 996px;
-
-      font-size: 80px;
-      line-height: 114%;
-    }
-  `;
-
-  return <SectionHeadline>{headline}</SectionHeadline>;
+  return <OverviewPages.Headline>{headline}</OverviewPages.Headline>;
 };
 
 export default SectionHeadline;

--- a/src/components/Content/Section/SectionSubline.js
+++ b/src/components/Content/Section/SectionSubline.js
@@ -1,48 +1,8 @@
 import React from "react";
-import styled from "@emotion/styled";
-
-import { Devices, Colors } from "../../DesignSystem";
+import { OverviewPages } from "../../DesignSystem";
 
 const SectionSubline = ({ subline }) => {
-  const SectionSubline = styled.p`
-    font-family: "Roboto", sans-serif;
-    font-weight: bold;
-    font-style: normal;
-
-    color: ${Colors.primaryText.mediumEmphasis};
-    margin-bottom: 8px;
-    margin-top: 0px;
-
-    font-size: 32px;
-    line-height: 112%;
-    text-align: left;
-    width: 100%;
-
-    ${Devices.tabletS} {
-      text-align: left;
-      width: 576px;
-    }
-    ${Devices.tabletM} {
-      width: 708px;
-
-      font-size: 36px;
-      line-height: 111%;
-    }
-    ${Devices.laptopS} {
-      width: 852px;
-
-      font-size: 48px;
-      line-height: 100%;
-    }
-    ${Devices.laptopM} {
-      width: 1141px;
-
-      font-size: 60px;
-      line-height: 113%;
-    }
-  `;
-
-  return <SectionSubline>{subline}</SectionSubline>;
+  return <OverviewPages.Subline>{subline}</OverviewPages.Subline>;
 };
 
 export default SectionSubline;

--- a/src/components/DesignSystem.js
+++ b/src/components/DesignSystem.js
@@ -374,3 +374,152 @@ export const ArticleSubline = styled.p`
     width: 650px;
   }
 `;
+
+const OverviewPageHeadline = styled.h2`
+  font-family: "Roboto", sans-serif;
+  font-weight: 400;
+  font-style: normal;
+
+  color: ${Colors.primaryText.highEmphasis};
+  margin-bottom: 8px;
+  margin-top: 0px;
+
+  font-size: 44px;
+  line-height: 109%;
+  text-align: left;
+
+  ${Devices.tabletS} {
+    text-align: left;
+    width: 564px;
+  }
+
+  ${Devices.tabletM} {
+    width: 708px;
+    font-size: 44px;
+    line-height: 114%;
+  }
+
+  ${Devices.laptopS} {
+    width: 852px;
+    font-size: 64px;
+    line-height: 131%;
+  }
+
+  ${Devices.laptopM} {
+    width: 996px;
+    font-size: 80px;
+    line-height: 114%;
+  }
+`;
+
+const OverviewPageSubline = styled.p`
+  font-family: "Roboto", sans-serif;
+  font-weight: 500;
+  font-style: normal;
+
+  color: ${Colors.primaryText.mediumEmphasis};
+  margin-bottom: 8px;
+  margin-top: 0px;
+
+  font-size: 32px;
+  line-height: 112%;
+  text-align: left;
+  width: 100%;
+
+  ${Devices.tabletS} {
+    text-align: left;
+    width: 576px;
+  }
+
+  ${Devices.tabletM} {
+    width: 708px;
+    font-size: 36px;
+    line-height: 111%;
+  }
+
+  ${Devices.laptopS} {
+    width: 852px;
+    font-size: 48px;
+    line-height: 100%;
+  }
+
+  ${Devices.laptopM} {
+    width: 1141px;
+    font-size: 60px;
+    line-height: 113%;
+  }
+`;
+
+const OverviewPageCopy = styled.p`
+  font-family: "Roboto", sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  color: ${Colors.primaryText.highEmphasis};
+  margin: 0px 24px 24px 24px;
+
+  font-size: 20px;
+  line-height: 120%;
+  text-align: left;
+
+  ${Devices.tabletS} {
+    text-align: left;
+    width: 576px;
+  }
+
+  ${Devices.tabletM} {
+    width: 720px;
+    font-size: 36px;
+    line-height: 111%;
+    margin-bottom: 32px;
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
+  ${Devices.laptopS} {
+    width: 864px;
+    font-size: 36px;
+    line-height: 100%;
+    margin-bottom: 38px;
+  }
+
+  ${Devices.laptopM} {
+    width: 1152px;
+    font-size: 42px;
+    line-height: 113%;
+    margin-bottom: 46px;
+  }
+`;
+
+const OverviewPageSummary = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  text-align: left;
+
+  margin: 0px 24px 60px 24px;
+
+  &:last-child {
+    margin-bottom: 0px;
+  }
+
+  ${Devices.tabletS} {
+    width: 100%;
+    margin: 0px 0px 60px 0px;
+  }
+
+  ${Devices.tabletM} {
+    width: 90%;
+  }
+
+  ${Devices.laptop} {
+    width: 80%;
+  }
+`;
+
+export const OverviewPages = {
+  Headline: OverviewPageHeadline,
+  Subline: OverviewPageSubline,
+  Copy: OverviewPageCopy,
+  Summary: OverviewPageSummary,
+};


### PR DESCRIPTION
## Summary
- add an Overview Pages style set to the design system that unifies headline, subline, copy, and summary typography with the requested font weights
- refactor section and case summary components to consume the centralized overview styles for consistent presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da34e60de0832799f68b0a9f8bff26