### PR TITLE
Align overline widths on case studies and reports

### DIFF
--- a/src/components/Content/Case/CaseTitleEyebrow.js
+++ b/src/components/Content/Case/CaseTitleEyebrow.js
@@ -33,7 +33,7 @@ const CaseTitleEyebrow = ({ text, color1, color2 }) => {
     -webkit-box-direction: normal;
     -webkit-font-smoothing: antialiased;
 
-    font-weight: 700;
+    font-weight: 500;
     font-size: 16px;
     line-height: 120%;
     width: 90%;
@@ -44,13 +44,13 @@ const CaseTitleEyebrow = ({ text, color1, color2 }) => {
     background-clip: text;
 
     ${Devices.tabletS} {
-      width: 564px;
+      width: 520px;
     }
     ${Devices.tabletM} {
-      width: 708px;
+      width: 520px;
     }
     ${Devices.laptopS} {
-      width: 740px;
+      width: 650px;
     }
   `;
 

--- a/src/components/Content/Report/ReportEyebrow.js
+++ b/src/components/Content/Report/ReportEyebrow.js
@@ -33,7 +33,7 @@ const ReportEyebrow = ({ text, color1, color2 }) => {
     -webkit-box-direction: normal;
     -webkit-font-smoothing: antialiased;
 
-    font-weight: 700;
+    font-weight: 500;
     font-size: 16px;
     line-height: 120%;
     width: 90%;
@@ -51,7 +51,7 @@ const ReportEyebrow = ({ text, color1, color2 }) => {
     }
     ${Devices.laptopS} {
       width: 650px;
-
+    }
   `;
 
   return <ReportEyebrow>{text}</ReportEyebrow>;


### PR DESCRIPTION
## Summary
- match the case study overline width breakpoints to the corresponding headlines
- normalize the report overline styling and close the laptop breakpoint block
- update both overlines to use a medium font weight for visual consistency

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68da35559df883278755d7c8a0dc02f8