### PR TITLE
Adjust overview summary font weight

### DIFF
--- a/src/components/DesignSystem.js
+++ b/src/components/DesignSystem.js
@@ -453,7 +453,7 @@ const OverviewPageSubline = styled.p`
 const OverviewPageCopy = styled.p`
   font-family: "Roboto", sans-serif;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 300;
   color: ${Colors.primaryText.highEmphasis};
   margin: 0px 24px 24px 24px;
 


### PR DESCRIPTION
## Summary
- reduce the font weight of the overview copy text to match the requested styling for Case Studies, Reports, and Flow Gallery pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da68dae0b4832786523ecc6f307b4a