### PR TITLE
Adjust FlowItem card width for responsive design

### DIFF
--- a/src/components/Content/FlowCarousel/FlowItem.js
+++ b/src/components/Content/FlowCarousel/FlowItem.js
@@ -5,7 +5,7 @@ import { Colors, Devices } from "../../DesignSystem";
 
 const FlowItemCard = styled.div`
   border-radius: 12px;
-  width: 480px;
+  width: 100%;
   height: 100%;
   margin: 0;
   display: block;
@@ -14,6 +14,10 @@ const FlowItemCard = styled.div`
   border-color: rgb(194, 194, 194);
   border-width: 1px;
   border-style: solid;
+
+  ${Devices.tabletS} {
+    width: 480px;
+  }
 `;
 
 const FlowItemWrapper = styled.div`


### PR DESCRIPTION
## Summary
- set FlowItemCard to span full width on mobile
- restore the 480px width from the small tablet breakpoint upward for consistent layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbacffea648327886aa02a3cfec543