### PR TITLE
Enable snap alignment for flow carousel

### DIFF
--- a/src/components/Content/FlowCarousel/FlowCarousel.js
+++ b/src/components/Content/FlowCarousel/FlowCarousel.js
@@ -25,6 +25,12 @@ const CarouselViewport = styled.div`
   border-radius: inherit;
   width: 100%;
   height: 100%;
+  scroll-snap-type: x mandatory;
+  scroll-padding-inline: 20px;
+
+  ${Devices.tabletS} {
+    scroll-padding-inline: 330px;
+  }
 `;
 
 const CarouselContent = styled.div`
@@ -98,9 +104,19 @@ const FlowCarousel = ({ data, appname, url }) => {
         <CarouselViewport>
           <CarouselContent>
             <CarouselGrid>
-              {data.map((item) => (
-                <FlowItem key={item.id} {...item} image={item.image} />
-              ))}
+              {data.map((item, index) => {
+                const isFirst = index === 0;
+                const isLast = index === data.length - 1;
+
+                return (
+                  <FlowItem
+                    key={item.id}
+                    {...item}
+                    image={item.image}
+                    snapAlignment={isFirst ? "start" : isLast ? "end" : "center"}
+                  />
+                );
+              })}
             </CarouselGrid>
           </CarouselContent>
         </CarouselViewport>

--- a/src/components/Content/FlowCarousel/FlowItem.js
+++ b/src/components/Content/FlowCarousel/FlowItem.js
@@ -14,6 +14,8 @@ const FlowItemCard = styled.div`
   border-color: rgb(194, 194, 194);
   border-width: 1px;
   border-style: solid;
+  scroll-snap-align: ${(props) => props.snapAlignment};
+  scroll-snap-stop: always;
 
   ${Devices.tabletS} {
     width: 480px;
@@ -68,9 +70,9 @@ const FlowItemPicture = styled.img`
   height: 100%;
 `;
 
-const FlowItem = ({ image }) => {
+const FlowItem = ({ image, snapAlignment = "center" }) => {
   return (
-    <FlowItemCard>
+    <FlowItemCard snapAlignment={snapAlignment}>
       <FlowItemWrapper>
         <FlowItemLink
           href={image || undefined}


### PR DESCRIPTION
## Summary
- add scroll snap behavior to the flow carousel viewport
- align flow carousel items so the first snaps left, the last snaps right, and the rest snap centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbaee82b2c8327be3224011ae77224