### PR TITLE
Update FlowCarousel and Chip components for improved styling and responsiveness

### DIFF
--- a/src/components/Content/FlowCarousel/FlowCarousel.js
+++ b/src/components/Content/FlowCarousel/FlowCarousel.js
@@ -41,7 +41,7 @@ const CarouselGrid = styled.div`
   display: flex;
   gap: 24px;
   padding: 4px 20px 10px 20px;
-  width: min-content;
+  width: 80%;
 
   ${Devices.tabletS} {
     padding: 4px 330px 10px 330px;
@@ -113,7 +113,9 @@ const FlowCarousel = ({ data, appname, url }) => {
                     key={item.id}
                     {...item}
                     image={item.image}
-                    snapAlignment={isFirst ? "start" : isLast ? "end" : "center"}
+                    snapAlignment={
+                      isFirst ? "start" : isLast ? "end" : "center"
+                    }
                   />
                 );
               })}

--- a/src/components/Layout/Chips.js
+++ b/src/components/Layout/Chips.js
@@ -8,6 +8,7 @@ export const ChipRow = styled.div`
   flex-wrap: wrap;
   gap: 12px;
   width: 90%;
+  margin-top: 12px;
 
   ${Devices.tabletS} {
     width: 564px;
@@ -25,7 +26,7 @@ export const ChipPill = styled.div`
   font-size: 14px;
   font-style: normal;
   font-weight: 400;
-  color: ${Colors.primaryText.highEmphasis};
+  color: ${Colors.greyLight};
   background-color: white;
   border-radius: 20px;
   padding: 8px 16px 8px 16px;


### PR DESCRIPTION
- Set FlowCarousel width to 80% for better layout adaptability.
- Adjusted snap alignment formatting for clarity.
- Added margin-top to ChipRow for enhanced spacing.
- Changed ChipPill text color to a lighter grey for better contrast.